### PR TITLE
Fixed issue with very small numbers

### DIFF
--- a/autoNumeric.js
+++ b/autoNumeric.js
@@ -233,29 +233,26 @@
      * function to handle numbers less than 0 that are stored in Exponential notation ex: .0000001 stored as 1e-7
      */
     function checkValue(value, settings) {
-        var decimal = value.indexOf('.'),
-            checkSmall = +value;
-        if (decimal !== -1) {
-            if (checkSmall < 0.000001 && checkSmall > -1) {
-                value = +value;
-                if (value < 0.000001 && value > 0) {
-                    value = (value + 10).toString();
-                    value = value.substring(1);
-                }
-                if (value < 0 && value > -1) {
-                    value = (value - 10).toString();
-                    value = '-' + value.substring(2);
-                }
-                value = value.toString();
-            } else {
-                var parts = value.split('.');
-                if (parts[1] !== undefined) {
-                    if (+parts[1] === 0) {
-                        value = parts[0];
-                    } else {
-                        parts[1] = parts[1].replace(/0*$/, '');
-                        value = parts.join('.');
-                    }
+        var checkSmall = +value;
+        if (checkSmall < 0.000001 && checkSmall > -1) {
+            value = +value;
+            if (value < 0.000001 && value > 0) {
+                value = (value + 10).toString();
+                value = value.substring(1);
+            }
+            if (value < 0 && value > -1) {
+                value = (value - 10).toString();
+                value = '-' + value.substring(2);
+            }
+            value = value.toString();
+        } else {
+            var parts = value.split('.');
+            if (parts[1] !== undefined) {
+                if (+parts[1] === 0) {
+                    value = parts[0];
+                } else {
+                    parts[1] = parts[1].replace(/0*$/, '');
+                    value = parts.join('.');
                 }
             }
         }


### PR DESCRIPTION
If an autoNumeric field was set with a very small value, such as 
0.00000000001, the value displayed in the input field would be incorrect
(0.00000000001 displays '111').

I'm not sure what the check for decimal was there for - as far as I can tell, the function works correctly without it. This is only an issue if the "very small number" only has 1 non-zero digit. For example, 0.000000000012 works because in scientific notation, it becomes 1.2e-11 (ie, it has a decimal point). A number like 0.00000000001 becomes 1e-11 (note no decimal point).

I don't know if different browser versions have an effect here, I tested this in Google Chrome, Firefox and IE 9, and the issue existed in all of them.
