### PR TITLE
Don't return 0 from checkValue if value is empty string

### DIFF
--- a/autoNumeric.js
+++ b/autoNumeric.js
@@ -233,26 +233,28 @@
      * function to handle numbers less than 0 that are stored in Exponential notation ex: .0000001 stored as 1e-7
      */
     function checkValue(value, settings) {
-        var checkSmall = +value;
-        if (checkSmall < 0.000001 && checkSmall > -1) {
-            value = +value;
-            if (value < 0.000001 && value > 0) {
-                value = (value + 10).toString();
-                value = value.substring(1);
-            }
-            if (value < 0 && value > -1) {
-                value = (value - 10).toString();
-                value = '-' + value.substring(2);
-            }
-            value = value.toString();
-        } else {
-            var parts = value.split('.');
-            if (parts[1] !== undefined) {
-                if (+parts[1] === 0) {
-                    value = parts[0];
-                } else {
-                    parts[1] = parts[1].replace(/0*$/, '');
-                    value = parts.join('.');
+        if (value) {
+            var checkSmall = +value;
+            if (checkSmall < 0.000001 && checkSmall > -1) {
+                value = +value;
+                if (value < 0.000001 && value > 0) {
+                    value = (value + 10).toString();
+                    value = value.substring(1);
+                }
+                if (value < 0 && value > -1) {
+                    value = (value - 10).toString();
+                    value = '-' + value.substring(2);
+                }
+                value = value.toString();
+            } else {
+                var parts = value.split('.');
+                if (parts[1] !== undefined) {
+                    if (+parts[1] === 0) {
+                        value = parts[0];
+                    } else {
+                        parts[1] = parts[1].replace(/0*$/, '');
+                        value = parts.join('.');
+                    }
                 }
             }
         }


### PR DESCRIPTION
Further to my previous change, without the check for decimals in checkValue, it's important to make sure that the string is not empty, otherwise checkValue returns '0' if the value is ''.

As far as I can tell, value will always be a string, so I think the if check I've added should be ok.
