### PR TITLE
Make default public and ovveridable

### DIFF
--- a/autoNumeric.js
+++ b/autoNumeric.js
@@ -850,105 +850,7 @@
                     settings = $this.data('autoNumeric'), /** attempt to grab 'autoNumeric' settings, if they don't exist returns "undefined". */
                     tagData = $this.data(); /** attempt to grab HTML5 data, if they don't exist we'll get "undefined".*/
                 if (typeof settings !== 'object') { /** If we couldn't grab settings, create them from defaults and passed options. */
-                    var defaults = {
-                        /** allowed numeric values
-                         * please do not modify
-                         */
-                        aNum: '0123456789',
-                        /** allowed thousand separator characters
-                         * comma = ','
-                         * period "full stop" = '.'
-                         * apostrophe is escaped = '\''
-                         * space = ' '
-                         * none = ''
-                         * NOTE: do not use numeric characters
-                         */
-                        aSep: ',',
-                        /** digital grouping for the thousand separator used in Format
-                         * dGroup: '2', results in 99,99,99,999 common in India for values less than 1 billion and greater than -1 billion
-                         * dGroup: '3', results in 999,999,999 default
-                         * dGroup: '4', results in 9999,9999,9999 used in some Asian countries
-                         */
-                        dGroup: '3',
-                        /** allowed decimal separator characters
-                         * period "full stop" = '.'
-                         * comma = ','
-                         */
-                        aDec: '.',
-                        /** allow to declare alternative decimal separator which is automatically replaced by aDec
-                         * developed for countries the use a comma ',' as the decimal character
-                         * and have keyboards\numeric pads that have a period 'full stop' as the decimal characters (Spain is an example)
-                         */
-                        altDec: null,
-                        /** allowed currency symbol
-                         * Must be in quotes aSign: '$', a space is allowed aSign: '$ '
-                         */
-                        aSign: '',
-                        /** placement of currency sign
-                         * for prefix pSign: 'p',
-                         * for suffix pSign: 's',
-                         */
-                        pSign: 'p',
-                        /** maximum possible value
-                         * value must be enclosed in quotes and use the period for the decimal point
-                         * value must be larger than vMin
-                         */
-                        vMax: '9999999999999.99',
-                        /** minimum possible value
-                         * value must be enclosed in quotes and use the period for the decimal point
-                         * value must be smaller than vMax
-                         */
-                        vMin: '0.00',
-                        /** max number of decimal places = used to override decimal places set by the vMin & vMax values
-                         * value must be enclosed in quotes example mDec: '3',
-                         * This can also set the value via a call back function mDec: 'css:#
-                         */
-                        mDec: null,
-                        /** method used for rounding
-                         * mRound: 'S', Round-Half-Up Symmetric (default)
-                         * mRound: 'A', Round-Half-Up Asymmetric
-                         * mRound: 's', Round-Half-Down Symmetric (lower case s)
-                         * mRound: 'a', Round-Half-Down Asymmetric (lower case a)
-                         * mRound: 'B', Round-Half-Even "Bankers Rounding"
-                         * mRound: 'U', Round Up "Round-Away-From-Zero"
-                         * mRound: 'D', Round Down "Round-Toward-Zero" - same as truncate
-                         * mRound: 'C', Round to Ceiling "Toward Positive Infinity"
-                         * mRound: 'F', Round to Floor "Toward Negative Infinity"
-                         */
-                        mRound: 'S',
-                        /** controls decimal padding
-                         * aPad: true - always Pad decimals with zeros
-                         * aPad: false - does not pad with zeros.
-                         * aPad: `some number` - pad decimals with zero to number different from mDec
-                         * thanks to Jonas Johansson for the suggestion
-                         */
-                        aPad: true,
-                        /** places brackets on negative value -$ 999.99 to (999.99)
-                         * visible only when the field does NOT have focus the left and right symbols should be enclosed in quotes and seperated by a comma
-                         * nBracket: null, nBracket: '(,)', nBracket: '[,]', nBracket: '<,>' or nBracket: '{,}'
-                         */
-                        nBracket: null,
-                        /** Displayed on empty string
-                         * wEmpty: 'empty', - input can be blank
-                         * wEmpty: 'zero', - displays zero
-                         * wEmpty: 'sign', - displays the currency sign
-                         */
-                        wEmpty: 'empty',
-                        /** controls leading zero behavior
-                         * lZero: 'allow', - allows leading zeros to be entered. Zeros will be truncated when entering additional digits. On focusout zeros will be deleted.
-                         * lZero: 'deny', - allows only one leading zero on values less than one
-                         * lZero: 'keep', - allows leading zeros to be entered. on fousout zeros will be retained.
-                         */
-                        lZero: 'allow',
-                        /** determine if the default value will be formatted on page ready.
-                         * true = automatically formats the default value on page ready
-                         * false = will not format the default value
-                         */
-                        aForm: true,
-                        /** future use */
-                        onSomeEvent: function () {}
-                    };
-                    settings = $.extend({}, defaults, tagData, options); /** Merge defaults, tagData and options */
+                    settings = $.extend({}, $.fn.autoNumeric.defaults, tagData, options); /** Merge defaults, tagData and options */
                     if (settings.aDec === settings.aSep) {
                         $.error("autoNumeric will not function properly when the decimal character aDec: '" + settings.aDec + "' and thousand separator aSep: '" + settings.aSep + "' are the same character");
                         return this;
@@ -1295,4 +1197,105 @@
         }
         $.error('Method "' + method + '" is not supported by autoNumeric()');
     };
+
+    /* Make defaults public */
+    $.fn.autoNumeric.defaults = {
+        /** allowed numeric values
+         * please do not modify
+         */
+        aNum: '0123456789',
+        /** allowed thousand separator characters
+         * comma = ','
+         * period "full stop" = '.'
+         * apostrophe is escaped = '\''
+         * space = ' '
+         * none = ''
+         * NOTE: do not use numeric characters
+         */
+        aSep: ',',
+        /** digital grouping for the thousand separator used in Format
+         * dGroup: '2', results in 99,99,99,999 common in India for values less than 1 billion and greater than -1 billion
+         * dGroup: '3', results in 999,999,999 default
+         * dGroup: '4', results in 9999,9999,9999 used in some Asian countries
+         */
+        dGroup: '3',
+        /** allowed decimal separator characters
+         * period "full stop" = '.'
+         * comma = ','
+         */
+        aDec: '.',
+        /** allow to declare alternative decimal separator which is automatically replaced by aDec
+         * developed for countries the use a comma ',' as the decimal character
+         * and have keyboards\numeric pads that have a period 'full stop' as the decimal characters (Spain is an example)
+         */
+        altDec: null,
+        /** allowed currency symbol
+         * Must be in quotes aSign: '$', a space is allowed aSign: '$ '
+         */
+        aSign: '',
+        /** placement of currency sign
+         * for prefix pSign: 'p',
+         * for suffix pSign: 's',
+         */
+        pSign: 'p',
+        /** maximum possible value
+         * value must be enclosed in quotes and use the period for the decimal point
+         * value must be larger than vMin
+         */
+        vMax: '9999999999999.99',
+        /** minimum possible value
+         * value must be enclosed in quotes and use the period for the decimal point
+         * value must be smaller than vMax
+         */
+        vMin: '0.00',
+        /** max number of decimal places = used to override decimal places set by the vMin & vMax values
+         * value must be enclosed in quotes example mDec: '3',
+         * This can also set the value via a call back function mDec: 'css:#
+         */
+        mDec: null,
+        /** method used for rounding
+         * mRound: 'S', Round-Half-Up Symmetric (default)
+         * mRound: 'A', Round-Half-Up Asymmetric
+         * mRound: 's', Round-Half-Down Symmetric (lower case s)
+         * mRound: 'a', Round-Half-Down Asymmetric (lower case a)
+         * mRound: 'B', Round-Half-Even "Bankers Rounding"
+         * mRound: 'U', Round Up "Round-Away-From-Zero"
+         * mRound: 'D', Round Down "Round-Toward-Zero" - same as truncate
+         * mRound: 'C', Round to Ceiling "Toward Positive Infinity"
+         * mRound: 'F', Round to Floor "Toward Negative Infinity"
+         */
+        mRound: 'S',
+        /** controls decimal padding
+         * aPad: true - always Pad decimals with zeros
+         * aPad: false - does not pad with zeros.
+         * aPad: `some number` - pad decimals with zero to number different from mDec
+         * thanks to Jonas Johansson for the suggestion
+         */
+        aPad: true,
+        /** places brackets on negative value -$ 999.99 to (999.99)
+         * visible only when the field does NOT have focus the left and right symbols should be enclosed in quotes and seperated by a comma
+         * nBracket: null, nBracket: '(,)', nBracket: '[,]', nBracket: '<,>' or nBracket: '{,}'
+         */
+        nBracket: null,
+        /** Displayed on empty string
+         * wEmpty: 'empty', - input can be blank
+         * wEmpty: 'zero', - displays zero
+         * wEmpty: 'sign', - displays the currency sign
+         */
+        wEmpty: 'empty',
+        /** controls leading zero behavior
+         * lZero: 'allow', - allows leading zeros to be entered. Zeros will be truncated when entering additional digits. On focusout zeros will be deleted.
+         * lZero: 'deny', - allows only one leading zero on values less than one
+         * lZero: 'keep', - allows leading zeros to be entered. on fousout zeros will be retained.
+         */
+        lZero: 'allow',
+        /** determine if the default value will be formatted on page ready.
+         * true = automatically formats the default value on page ready
+         * false = will not format the default value
+         */
+        aForm: true,
+        /** future use */
+        onSomeEvent: function () { }
+    };
+
 }(jQuery));


### PR DESCRIPTION
This change is really useful when we need to specify the default for a project based on current culture info.
By this point every project could specify the default for each page or, such in my case, in .NET MVC (or Asp.NET) in the master specify the global default.
In example:

```
<script type="text/javascript" src="js/jquery.autoNumeric.js" />
<script type="text/javascript">
    $(document).ready(function () {
        $.extend($.fn.autoNumeric.defaults, {
            aSep: '@System.Threading.Thread.CurrentThread.CurrentCulture.NumberFormat.NumberGroupSeparator',
            aDec: '@System.Threading.Thread.CurrentThread.CurrentCulture.NumberFormat.NumberDecimalSeparator'
        });
    });
</script>
```

You can override all the default values as you want by this way.
Hope this will help someone out there!

Peter
