### PR TITLE
Fix issue #440 Pasting does not work in IE11

### DIFF
--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -5312,8 +5312,16 @@ class AutoNumeric {
         // The event is prevented by default, since otherwise the user would be able to paste invalid characters into the input
         e.preventDefault();
 
-        // fall back to window.clipboardData if it exists (ie11 localhost/intranet)
-        let rawPastedText = (window.clipboardData ? window.clipboardData.getData('text') : e.clipboardData.getData('text/plain'));
+        let rawPastedText;
+        if (window.clipboardData && window.clipboardData.getData) {
+            // Special case for the obsolete and non-standard IE browsers 10 and 11
+            rawPastedText = window.clipboardData.getData('Text');
+        } else if (e.clipboardData && e.clipboardData.getData) {
+            // Normal case with modern browsers
+            rawPastedText = e.clipboardData.getData('text/plain');
+        } else {
+            AutoNumericHelper.throwError('Unable to retrieve the pasted value. Please use a modern browser (ie. Firefox or Chromium).');
+        }
 
         // 0. Special case if the user has selected all the input text before pasting
         const initialFormattedValue = AutoNumericHelper.getElementValue(e.target);

--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -5312,7 +5312,8 @@ class AutoNumeric {
         // The event is prevented by default, since otherwise the user would be able to paste invalid characters into the input
         e.preventDefault();
 
-        let rawPastedText = e.clipboardData.getData('text/plain');
+        // fall back to window.clipboardData if it exists (ie11 localhost/intranet)
+        let rawPastedText = (window.clipboardData ? window.clipboardData.getData('text') : e.clipboardData.getData('text/plain'));
 
         // 0. Special case if the user has selected all the input text before pasting
         const initialFormattedValue = AutoNumericHelper.getElementValue(e.target);


### PR DESCRIPTION
changed paste code to fall back to window.clipboardData if it exists (ie11 localhost/intranet)