### PR TITLE
Fix Browserify compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "autonumeric",
   "version": "4.0.0-beta.23",
   "description": "autoNumeric is a standalone Javascript library that provides live *as-you-type* formatting for international numbers and currencies. It supports most international numeric formats and currencies including those used in Europe, Asia, and North and South America.",
-  "main": "src/main.js",
+  "main": "dist/autoNumeric.js",
   "readmeFilename": "README.md",
   "keywords": [
     "currency",


### PR DESCRIPTION
This simply targets the built (non-minified) version of the library within the `package.json` so that Browserify's `require` works as intended, including when transpiling with Babelify.