### PR TITLE
Fix issue #505 Pasting values in a `readOnly` element should not be possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 4.1.0-beta.10
 + Fix issue #502 The end-to-end tests fails on Chrome 61
++ Fix issue #505 Pasting values in a `readOnly` element should not be possible
 
 ### 4.1.0-beta.9
 + Fix issue #498 The `twoScaled` choice for the `digitalGroupSpacing` option cannot be validated

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autonumeric",
-  "version": "4.1.0-beta.9",
+  "version": "4.1.0-beta.10",
   "description": "autoNumeric is a standalone Javascript library that provides live *as-you-type* formatting for international numbers and currencies. It supports most international numeric formats and currencies including those used in Europe, Asia, and North and South America.",
   "main": "dist/autoNumeric.js",
   "readmeFilename": "README.md",

--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -5978,6 +5978,11 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
         // The event is prevented by default, since otherwise the user would be able to paste invalid characters into the input
         e.preventDefault();
 
+        if (this.settings.readOnly) {
+            // Do not allow pasting in a readonly element (fix issue #505)
+            return;
+        }
+
         let rawPastedText;
         if (window.clipboardData && window.clipboardData.getData) {
             // Special case for the obsolete and non-standard IE browsers 10 and 11

--- a/test/e2e/specs/autoNumeric.e2e.spec.js
+++ b/test/e2e/specs/autoNumeric.e2e.spec.js
@@ -3708,4 +3708,24 @@ describe('Pasting', () => {
         browser.keys(['Control', 'a', 'v', 'Control']);
         expect(browser.getValue(selectors.issue387inputCancellable)).toEqual('$220,242.76');
     });
+
+    it('should not be possible to paste an valid number in a readOnly element', () => {
+        expect(browser.getValue(selectors.readOnlyElement)).toEqual('42.42');
+
+        const inputClassic = $(selectors.inputClassic);
+        inputClassic.click();
+        // Clear the input content
+        browser.keys(['Control', 'a', 'Control', 'Backspace']);
+        browser.keys('12345.67');
+        expect(browser.getValue(selectors.inputClassic)).toEqual('12345.67');
+
+        // Copy
+        browser.keys(['Control', 'a', 'c', 'Control']);
+
+        // Paste
+        $(selectors.readOnlyElement).click();
+        browser.keys(['Home', 'ArrowRight', 'Shift', 'ArrowRight', 'ArrowRight', 'Shift']);
+        browser.keys(['Control', 'a', 'v', 'Control']);
+        expect(browser.getValue(selectors.readOnlyElement)).toEqual('42.42'); // No changes!
+    });
 });


### PR DESCRIPTION
Signed-off-by: Alexandre Bonneau <alexandre.bonneau@linuxfr.eu>