### PR TITLE
Fix issue #455 Uncaught Error: `_initialCaretPosition()` should never be called when the `caretPositionOnFocus` option is `null`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog for autoNumeric
 
+### 4.1.0-beta.11
++ Fix issue #455 Uncaught Error: `_initialCaretPosition()` should never be called when the `caretPositionOnFocus` option is `null`
+
 ### 4.1.0-beta.10
 + Fix issue #502 The end-to-end tests fails on Chrome 61
 + Fix issue #505 Pasting values in a `readOnly` element should not be possible

--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -1,8 +1,8 @@
 /**
  *               AutoNumeric.js
  *
- * @version      4.1.0-beta.10
- * @date         2017-09-01 UTC 06:00
+ * @version      4.1.0-beta.11
+ * @date         2017-10-10 UTC 22:00
  *
  * @authors      Bob Knothe, Alexandre Bonneau
  * @contributors Sokolov Yura and others, cf. AUTHORS
@@ -847,7 +847,7 @@ export default class AutoNumeric {
      * @returns {string}
      */
     static version() {
-        return '4.1.0-beta.10';
+        return '4.1.0-beta.11';
     }
 
     /**
@@ -4671,7 +4671,8 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
      * @private
      */
     _initialCaretPosition(value) {
-        if (AutoNumericHelper.isNull(this.settings.caretPositionOnFocus)) {
+        if (AutoNumericHelper.isNull(this.settings.caretPositionOnFocus) &&
+            this.settings.selectOnFocus === AutoNumeric.options.selectOnFocus.doNotSelect) {
             AutoNumericHelper.throwError('`_initialCaretPosition()` should never be called when the `caretPositionOnFocus` option is `null`.');
         }
 
@@ -5493,7 +5494,9 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
             this.select();
         } else {
             // Or we decide where to put the caret using the `caretPositionOnFocus` option
-            AutoNumericHelper.setElementSelection(e.target, this._initialCaretPosition(AutoNumericHelper.getElementValue(this.domElement)));
+            if (!AutoNumericHelper.isNull(this.settings.caretPositionOnFocus)) {
+                AutoNumericHelper.setElementSelection(e.target, this._initialCaretPosition(AutoNumericHelper.getElementValue(this.domElement)));
+            }
         }
     }
 

--- a/test/e2e/index.html
+++ b/test/e2e/index.html
@@ -803,6 +803,13 @@
 			<input id="issue_498" type="text" placeholder="#498">
 		</div>
 	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #455</p>
+			<input id="issue_455" type="text" placeholder="#455">
+		</div>
+	</div>
 </div>
 <script>
     //-------------- Classic input
@@ -1758,7 +1765,13 @@
     //-------------- Issue #498
     new AutoNumeric('#issue_498', 12345678901234.5678, {
         digitalGroupSpacing: '2s',
-	    maximumValue       : '999999999999999',
+        maximumValue       : '999999999999999',
+    });
+
+    //-------------- Issue #455
+    new AutoNumeric('#issue_455', 1234.56, {
+        caretPositionOnFocus: AutoNumeric.options.caretPositionOnFocus.doNoForceCaretPosition,
+        selectOnFocus: AutoNumeric.options.selectOnFocus.doNotSelect,
     });
 </script>
 </body>


### PR DESCRIPTION
Signed-off-by: Alexandre Bonneau <alexandre.bonneau@linuxfr.eu>