### PR TITLE
Fix destructuring reference issue

### DIFF
--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -4888,7 +4888,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
             this.settings.firstBracket = '';
             this.settings.lastBracket  = '';
         } else {
-	    // Use temporary variables to fix the MS Edge destructuring issue (see PR #564)
+            // Use temporary variables to fix the MS Edge destructuring issue (see pull request #564)
             const [firstBracket, lastBracket] = this.settings.negativeBracketsTypeOnBlur.split(',');
             this.settings.firstBracket = firstBracket;
             this.settings.lastBracket = lastBracket;

--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -4888,6 +4888,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
             this.settings.firstBracket = '';
             this.settings.lastBracket  = '';
         } else {
+	    // Use temporary variables to fix the MS Edge destructuring issue (see PR #564)
             const [firstBracket, lastBracket] = this.settings.negativeBracketsTypeOnBlur.split(',');
             this.settings.firstBracket = firstBracket;
             this.settings.lastBracket = lastBracket;

--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -4888,7 +4888,9 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
             this.settings.firstBracket = '';
             this.settings.lastBracket  = '';
         } else {
-            [this.settings.firstBracket, this.settings.lastBracket] = this.settings.negativeBracketsTypeOnBlur.split(',');
+            const [firstBracket, lastBracket] = this.settings.negativeBracketsTypeOnBlur.split(',');
+            this.settings.firstBracket = firstBracket;
+            this.settings.lastBracket = lastBracket;
         }
     }
 


### PR DESCRIPTION
Destructuring to class properties is bugged on some MS Edge versions (14, 15). This PR fixes that.

Reference: https://github.com/Microsoft/ChakraCore/issues/2536