### PR TITLE
updated the logic of IsNegative function for supporting the case with  the '0.' as the left part

### DIFF
--- a/src/AutoNumericHelper.js
+++ b/src/AutoNumericHelper.js
@@ -508,12 +508,12 @@ export default class AutoNumericHelper {
             return false;
         }
 
-        if (checkEverywhere) {
-            return this.contains(numberOrNumericString, negativeSignCharacter);
+        if (AutoNumericHelper.isNumber(numberOrNumericString)) {
+            return numberOrNumericString < 0 || this.isNegativeStrict(numberOrNumericString, negativeSignCharacter);
         }
 
-        if (AutoNumericHelper.isNumber(numberOrNumericString)) {
-            return numberOrNumericString < 0;
+        if (checkEverywhere) {
+            return this.contains(numberOrNumericString, negativeSignCharacter);
         }
 
         return this.isNegativeStrict(numberOrNumericString, negativeSignCharacter);

--- a/src/AutoNumericHelper.js
+++ b/src/AutoNumericHelper.js
@@ -508,12 +508,12 @@ export default class AutoNumericHelper {
             return false;
         }
 
-        if (AutoNumericHelper.isNumber(numberOrNumericString)) {
-            return numberOrNumericString < 0;
-        }
-
         if (checkEverywhere) {
             return this.contains(numberOrNumericString, negativeSignCharacter);
+        }
+
+        if (AutoNumericHelper.isNumber(numberOrNumericString)) {
+            return numberOrNumericString < 0;
         }
 
         return this.isNegativeStrict(numberOrNumericString, negativeSignCharacter);


### PR DESCRIPTION
the string like '-0.' would not be account like an negative number. It leads to wrong behavior for number like this one: `-0.054`, setting the cursor before `5` and press the key `-`. The old behavior will do following: `-0.054` -> `-54`.