### PR TITLE
Allow `emptyInputBehavior` to be set to min, max, or a number

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ You can check what are the predefined choices for each option as well as a more 
 | `digitalGroupSpacing` | Digital grouping for the thousand separator | `'3'` |
 | `digitGroupSeparator` | Thousand separator character  | `','` |
 | `divisorWhenUnfocused` | Defines the number that will divide the current value shown when unfocused | `null` |
-| `emptyInputBehavior` | Defines what to display when the input value is empty (possible options are `null`, `focus`, `press`, `always` and `zero`) | `'focus'` |
+| `emptyInputBehavior` | Defines what to display when the input value is empty (possible options are `null`, `focus`, `press`, `always`, `min`, `max`, `zero`, number, or string representing a number) | `'focus'` |
 | `eventBubbles` | Defines if the custom and native events triggered by AutoNumeric should bubble up or not | `true` |
 | `eventIsCancelable` | Defines if the custom and native events triggered by AutoNumeric should be cancelable | `true` |
 | `failOnUnknownOption ` | This option is the 'strict mode' *(aka 'debug' mode)*, which allows autoNumeric to strictly analyse the options passed, and fails if an unknown options is used in the `options` object. | `false` |

--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -131,11 +131,6 @@ export default class AutoNumeric {
             let valueToSet;
             if (AutoNumericHelper.isNull(initialValue)) {
                 switch (this.settings.emptyInputBehavior) {
-                    case AutoNumeric.options.emptyInputBehavior.focus:
-                    case AutoNumeric.options.emptyInputBehavior.press:
-                    case AutoNumeric.options.emptyInputBehavior.always:
-                        valueToSet = '';
-                        break;
                     case AutoNumeric.options.emptyInputBehavior.min:
                         valueToSet = this.settings.minimumValue;
                         break;
@@ -147,6 +142,9 @@ export default class AutoNumeric {
                         break;
                     // In order to stay consistent when `formatOnPageLoad` is set to `true`, it's still impossible so set the `null` value as the initial value
                     case AutoNumeric.options.emptyInputBehavior.null:
+                    case AutoNumeric.options.emptyInputBehavior.focus:
+                    case AutoNumeric.options.emptyInputBehavior.press:
+                    case AutoNumeric.options.emptyInputBehavior.always:
                         valueToSet = '';
                         break;
                     // When emptyInputBehavior is a number or a string representing a number
@@ -1989,14 +1987,20 @@ export default class AutoNumeric {
         }
         
         if (value === '') {
-            if (this.settings.emptyInputBehavior === AutoNumeric.options.emptyInputBehavior.zero) {
-                value = 0;
-            } else if (this.settings.emptyInputBehavior === AutoNumeric.options.emptyInputBehavior.min) {
-                value = this.settings.minimumValue;
-            } else if (this.settings.emptyInputBehavior === AutoNumeric.options.emptyInputBehavior.max) {
-                value = this.settings.maximumValue;
-            } else if (AutoNumericHelper.isNumber(this.settings.emptyInputBehavior)) {
-                value = Number(this.settings.emptyInputBehavior);
+            switch (this.settings.emptyInputBehavior) {
+                case AutoNumeric.options.emptyInputBehavior.zero:
+                    value = 0;
+                    break;
+                case AutoNumeric.options.emptyInputBehavior.min:
+                    value = this.settings.minimumValue;
+                    break;
+                case AutoNumeric.options.emptyInputBehavior.max:
+                    value = this.settings.maximumValue; 
+                    break;
+                default:
+                    if (AutoNumericHelper.isNumber(this.settings.emptyInputBehavior)) {
+                        value = Number(this.settings.emptyInputBehavior);
+                    } 
             }
         }
 
@@ -3958,17 +3962,16 @@ export default class AutoNumeric {
             AutoNumericHelper.throwError(`The brackets for negative values option 'negativeBracketsTypeOnBlur' is invalid ; it should either be '(,)', '[,]', '<,>', '{,}', '〈,〉', '｢,｣', '⸤,⸥', '⟦,⟧', '‹,›' or '«,»', [${options.negativeBracketsTypeOnBlur}] given.`);
         }
 
-        const emptyInputBehaviorValueArray = [
-            AutoNumeric.options.emptyInputBehavior.focus,
-            AutoNumeric.options.emptyInputBehavior.press,
-            AutoNumeric.options.emptyInputBehavior.always,
-            AutoNumeric.options.emptyInputBehavior.min,
-            AutoNumeric.options.emptyInputBehavior.max,
-            AutoNumeric.options.emptyInputBehavior.zero,
-            AutoNumeric.options.emptyInputBehavior.null,
-        ];
         if (!(AutoNumericHelper.isString(options.emptyInputBehavior) || AutoNumericHelper.isNumber(options.emptyInputBehavior)) ||
-            !(AutoNumericHelper.isInArray(options.emptyInputBehavior, emptyInputBehaviorValueArray) || testFloatOrIntegerAndPossibleNegativeSign.test(options.emptyInputBehavior))) {
+            !(AutoNumericHelper.isInArray(options.emptyInputBehavior, [
+                AutoNumeric.options.emptyInputBehavior.focus,
+                AutoNumeric.options.emptyInputBehavior.press,
+                AutoNumeric.options.emptyInputBehavior.always,
+                AutoNumeric.options.emptyInputBehavior.min,
+                AutoNumeric.options.emptyInputBehavior.max,
+                AutoNumeric.options.emptyInputBehavior.zero,
+                AutoNumeric.options.emptyInputBehavior.null,
+            ]) || testFloatOrIntegerAndPossibleNegativeSign.test(options.emptyInputBehavior))) {
             AutoNumericHelper.throwError(`The display on empty string option 'emptyInputBehavior' is invalid ; it should either be 'focus', 'press', 'always', 'min', 'max', 'zero', 'null', a number, or a string that represents a number, [${options.emptyInputBehavior}] given.`);
         }
 
@@ -3978,7 +3981,7 @@ export default class AutoNumeric {
         }
 
         if (testPositiveFloatOrInteger.test(options.emptyInputBehavior) &&
-            (options.minimumValue > 0 || options.maximumValue < 0)) {
+            (options.minimumValue > options.emptyInputBehavior || options.maximumValue < options.emptyInputBehavior)) {
             AutoNumericHelper.throwError(`The 'emptyInputBehavior' option is set to a number or a string that represents a number, but this value is outside of the range defined by 'minimumValue' and 'maximumValue' [${options.minimumValue}, ${options.maximumValue}].`);
         }
 
@@ -6555,18 +6558,24 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
                         }
                     }
                 } else if (rawValueToFormat === '') {
-                    if (this.settings.emptyInputBehavior === AutoNumeric.options.emptyInputBehavior.zero) {
-                        this._setRawValue('0');
-                        value = this.constructor._roundValue('0', this.settings, 0);
-                    } else if (this.settings.emptyInputBehavior === AutoNumeric.options.emptyInputBehavior.min) {
-                        this._setRawValue(this.settings.minimumValue);
-                        value = this.constructor._roundFormattedValueShownOnFocusOrBlur(this.settings.minimumValue, this.settings, this.isFocused);
-                    } else if (this.settings.emptyInputBehavior === AutoNumeric.options.emptyInputBehavior.max) {
-                        this._setRawValue(this.settings.maximumValue);
-                        value = this.constructor._roundFormattedValueShownOnFocusOrBlur(this.settings.maximumValue, this.settings, this.isFocused);
-                    } else if (AutoNumericHelper.isNumber(this.settings.emptyInputBehavior)) {
-                        this._setRawValue(this.settings.emptyInputBehavior);
-                        value = this.constructor._roundFormattedValueShownOnFocusOrBlur(this.settings.emptyInputBehavior, this.settings, this.isFocused);
+                    switch (this.settings.emptyInputBehavior) {
+                        case AutoNumeric.options.emptyInputBehavior.zero:
+                            this._setRawValue('0');
+                            value = this.constructor._roundValue('0', this.settings, 0); 
+                            break;
+                        case AutoNumeric.options.emptyInputBehavior.min:
+                            this._setRawValue(this.settings.minimumValue);
+                            value = this.constructor._roundFormattedValueShownOnFocusOrBlur(this.settings.minimumValue, this.settings, this.isFocused); 
+                            break;
+                        case AutoNumeric.options.emptyInputBehavior.max:
+                            this._setRawValue(this.settings.maximumValue);
+                            value = this.constructor._roundFormattedValueShownOnFocusOrBlur(this.settings.maximumValue, this.settings, this.isFocused); 
+                            break;
+                        default:
+                            if (AutoNumericHelper.isNumber(this.settings.emptyInputBehavior)) {
+                                this._setRawValue(this.settings.emptyInputBehavior);
+                                value = this.constructor._roundFormattedValueShownOnFocusOrBlur(this.settings.emptyInputBehavior, this.settings, this.isFocused);
+                            }
                     }
                 }
 
@@ -7388,32 +7397,24 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
             if (currentValue === '') {
                 switch (this.settings.emptyInputBehavior) {
                     case AutoNumeric.options.emptyInputBehavior.focus:
-                        setValue = false;
-                        break;
                     case AutoNumeric.options.emptyInputBehavior.null:
                     case AutoNumeric.options.emptyInputBehavior.press:
-                        //TODO What about the `AutoNumeric.options.emptyInputBehavior.press` value?
                         break;
                     case AutoNumeric.options.emptyInputBehavior.always:
                         this._setElementValue(this.settings.currencySymbol);
-                        setValue = false;
                         break;
                     case AutoNumeric.options.emptyInputBehavior.min:
                         this.set(this.settings.minimumValue);
-                        setValue = false;
                         break;
                     case AutoNumeric.options.emptyInputBehavior.max:
                         this.set(this.settings.maximumValue);
-                        setValue = false;
                         break;
                     case AutoNumeric.options.emptyInputBehavior.zero:
                         this.set('0');
-                        setValue = false;
                         break;
                     // When emptyInputBehavior is a number or a string representing a number
                     default:
                         this.set(this.settings.emptyInputBehavior);
-                        setValue = false;
                 }
             } else if (setValue && currentValue === this.domElement.getAttribute('value')) {
                 this.set(currentValue);

--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -131,13 +131,27 @@ export default class AutoNumeric {
             let valueToSet;
             if (AutoNumericHelper.isNull(initialValue)) {
                 switch (this.settings.emptyInputBehavior) {
+                    case AutoNumeric.options.emptyInputBehavior.focus:
+                    case AutoNumeric.options.emptyInputBehavior.press:
+                    case AutoNumeric.options.emptyInputBehavior.always:
+                        valueToSet = '';
+                        break;
+                    case AutoNumeric.options.emptyInputBehavior.min:
+                        valueToSet = this.settings.minimumValue;
+                        break;
+                    case AutoNumeric.options.emptyInputBehavior.max:
+                        valueToSet = this.settings.maximumValue;
+                        break;
                     case AutoNumeric.options.emptyInputBehavior.zero:
                         valueToSet = '0';
                         break;
                     // In order to stay consistent when `formatOnPageLoad` is set to `true`, it's still impossible so set the `null` value as the initial value
                     case AutoNumeric.options.emptyInputBehavior.null:
-                    default :
                         valueToSet = '';
+                        break;
+                    // When emptyInputBehavior is a number or a string representing a number
+                    default :
+                        valueToSet = this.settings.emptyInputBehavior;
                 }
             } else {
                 valueToSet = initialValue;
@@ -1974,9 +1988,16 @@ export default class AutoNumeric {
             return this;
         }
         
-        if (value === '' && this.settings.emptyInputBehavior === AutoNumeric.options.emptyInputBehavior.zero) {
-            // Keep the value zero inside the element
-            value = 0;
+        if (value === '') {
+            if (this.settings.emptyInputBehavior === AutoNumeric.options.emptyInputBehavior.zero) {
+                value = 0;
+            } else if (this.settings.emptyInputBehavior === AutoNumeric.options.emptyInputBehavior.min) {
+                value = this.settings.minimumValue;
+            } else if (this.settings.emptyInputBehavior === AutoNumeric.options.emptyInputBehavior.max) {
+                value = this.settings.maximumValue;
+            } else if (AutoNumericHelper.isNumber(this.settings.emptyInputBehavior)) {
+                value = Number(this.settings.emptyInputBehavior);
+            }
         }
 
         if (value !== '') {
@@ -3937,19 +3958,28 @@ export default class AutoNumeric {
             AutoNumericHelper.throwError(`The brackets for negative values option 'negativeBracketsTypeOnBlur' is invalid ; it should either be '(,)', '[,]', '<,>', '{,}', '〈,〉', '｢,｣', '⸤,⸥', '⟦,⟧', '‹,›' or '«,»', [${options.negativeBracketsTypeOnBlur}] given.`);
         }
 
-        if (!AutoNumericHelper.isInArray(options.emptyInputBehavior, [
+        const emptyInputBehaviorValueArray = [
             AutoNumeric.options.emptyInputBehavior.focus,
             AutoNumeric.options.emptyInputBehavior.press,
             AutoNumeric.options.emptyInputBehavior.always,
+            AutoNumeric.options.emptyInputBehavior.min,
+            AutoNumeric.options.emptyInputBehavior.max,
             AutoNumeric.options.emptyInputBehavior.zero,
             AutoNumeric.options.emptyInputBehavior.null,
-        ])) {
-            AutoNumericHelper.throwError(`The display on empty string option 'emptyInputBehavior' is invalid ; it should either be 'focus', 'press', 'always', 'zero' or 'null', [${options.emptyInputBehavior}] given.`);
+        ];
+        if (!(AutoNumericHelper.isString(options.emptyInputBehavior) || AutoNumericHelper.isNumber(options.emptyInputBehavior)) ||
+            !(AutoNumericHelper.isInArray(options.emptyInputBehavior, emptyInputBehaviorValueArray) || testFloatOrIntegerAndPossibleNegativeSign.test(options.emptyInputBehavior))) {
+            AutoNumericHelper.throwError(`The display on empty string option 'emptyInputBehavior' is invalid ; it should either be 'focus', 'press', 'always', 'min', 'max', 'zero', 'null', a number, or a string that represents a number, [${options.emptyInputBehavior}] given.`);
         }
 
         if (options.emptyInputBehavior === AutoNumeric.options.emptyInputBehavior.zero &&
             (options.minimumValue > 0 || options.maximumValue < 0)) {
             AutoNumericHelper.throwError(`The 'emptyInputBehavior' option is set to 'zero', but this value is outside of the range defined by 'minimumValue' and 'maximumValue' [${options.minimumValue}, ${options.maximumValue}].`);
+        }
+
+        if (testPositiveFloatOrInteger.test(options.emptyInputBehavior) &&
+            (options.minimumValue > 0 || options.maximumValue < 0)) {
+            AutoNumericHelper.throwError(`The 'emptyInputBehavior' option is set to a number or a string that represents a number, but this value is outside of the range defined by 'minimumValue' and 'maximumValue' [${options.minimumValue}, ${options.maximumValue}].`);
         }
 
         if (!AutoNumericHelper.isTrueOrFalseString(options.eventBubbles) && !AutoNumericHelper.isBoolean(options.eventBubbles)) {
@@ -5518,7 +5548,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
     }
 
     /**
-     * Round the given `value` with the number of decimal places to show for the element is focused.
+     * Round the given `value` with the number of decimal places to show for the element if focused.
      *
      * @param {string|null} value An unformatted numeric value
      * @param {object} settings
@@ -5530,7 +5560,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
     }
 
     /**
-     * Round the given `value` with the number of decimal places to show for the element is unfocused.
+     * Round the given `value` with the number of decimal places to show for the element if unfocused.
      *
      * @param {string|null} value An unformatted numeric value
      * @param {object} settings
@@ -5539,6 +5569,23 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
      */
     static _roundFormattedValueShownOnBlur(value, settings) {
         return this._roundValue(value, settings, Number(settings.decimalPlacesShownOnBlur));
+    }
+
+    /**
+     * Round the given `value` with the number of decimal places to show for the element based on the value of isFocused.
+     *
+     * @param {string|null} value An unformatted numeric value
+     * @param {object} settings
+     * @param {boolean} isFocused
+     * @returns {*}
+     * @private
+     */
+    static _roundFormattedValueShownOnFocusOrBlur(value, settings, isFocused) {
+        if (isFocused) {
+            return this._roundFormattedValueShownOnFocus(value, settings);
+        } else {
+            return this._roundFormattedValueShownOnBlur(value, settings);
+        }
     }
 
     /**
@@ -6034,12 +6081,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
             // Modify the element value according to the number of decimal places to show on focus or the `showOnlyNumbersOnFocus` option
             if (rawValueToFormat !== '') {
                 // Round the given value according to the object state (focus/unfocused)
-                let roundedValue;
-                if (this.isFocused) {
-                    roundedValue = this.constructor._roundFormattedValueShownOnFocus(rawValueToFormat, this.settings);
-                } else {
-                    roundedValue = this.constructor._roundFormattedValueShownOnBlur(rawValueToFormat, this.settings);
-                }
+                const roundedValue = this.constructor._roundFormattedValueShownOnFocusOrBlur(rawValueToFormat, this.settings, this.isFocused);
 
                 if (this.settings.showOnlyNumbersOnFocus === AutoNumeric.options.showOnlyNumbersOnFocus.onlyNumbers) {
                     //TODO Use a `this.settingsOverride` object instead of modifying the `this.settings` object
@@ -6512,9 +6554,20 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
                             this._triggerEvent(AutoNumeric.events.maxRangeExceeded, this.domElement);
                         }
                     }
-                } else if (rawValueToFormat === '' && this.settings.emptyInputBehavior === AutoNumeric.options.emptyInputBehavior.zero) {
-                    this._setRawValue('0');
-                    value = this.constructor._roundValue('0', this.settings, 0);
+                } else if (rawValueToFormat === '') {
+                    if (this.settings.emptyInputBehavior === AutoNumeric.options.emptyInputBehavior.zero) {
+                        this._setRawValue('0');
+                        value = this.constructor._roundValue('0', this.settings, 0);
+                    } else if (this.settings.emptyInputBehavior === AutoNumeric.options.emptyInputBehavior.min) {
+                        this._setRawValue(this.settings.minimumValue);
+                        value = this.constructor._roundFormattedValueShownOnFocusOrBlur(this.settings.minimumValue, this.settings, this.isFocused);
+                    } else if (this.settings.emptyInputBehavior === AutoNumeric.options.emptyInputBehavior.max) {
+                        this._setRawValue(this.settings.maximumValue);
+                        value = this.constructor._roundFormattedValueShownOnFocusOrBlur(this.settings.maximumValue, this.settings, this.isFocused);
+                    } else if (AutoNumericHelper.isNumber(this.settings.emptyInputBehavior)) {
+                        this._setRawValue(this.settings.emptyInputBehavior);
+                        value = this.constructor._roundFormattedValueShownOnFocusOrBlur(this.settings.emptyInputBehavior, this.settings, this.isFocused);
+                    }
                 }
 
 
@@ -7337,17 +7390,30 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
                     case AutoNumeric.options.emptyInputBehavior.focus:
                         setValue = false;
                         break;
-                    //TODO What about the `AutoNumeric.options.emptyInputBehavior.press` value?
+                    case AutoNumeric.options.emptyInputBehavior.null:
+                    case AutoNumeric.options.emptyInputBehavior.press:
+                        //TODO What about the `AutoNumeric.options.emptyInputBehavior.press` value?
+                        break;
                     case AutoNumeric.options.emptyInputBehavior.always:
                         this._setElementValue(this.settings.currencySymbol);
+                        setValue = false;
+                        break;
+                    case AutoNumeric.options.emptyInputBehavior.min:
+                        this.set(this.settings.minimumValue);
+                        setValue = false;
+                        break;
+                    case AutoNumeric.options.emptyInputBehavior.max:
+                        this.set(this.settings.maximumValue);
                         setValue = false;
                         break;
                     case AutoNumeric.options.emptyInputBehavior.zero:
                         this.set('0');
                         setValue = false;
                         break;
-                    default :
-                    //
+                    // When emptyInputBehavior is a number or a string representing a number
+                    default:
+                        this.set(this.settings.emptyInputBehavior);
+                        setValue = false;
                 }
             } else if (setValue && currentValue === this.domElement.getAttribute('value')) {
                 this.set(currentValue);
@@ -8130,14 +8196,26 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
             if (testValue === '' || testValue === this.settings.negativeSignCharacter) {
                 let valueToSetOnEmpty;
                 switch (this.settings.emptyInputBehavior) {
+                    case AutoNumeric.options.emptyInputBehavior.focus:
+                    case AutoNumeric.options.emptyInputBehavior.press:
+                    case AutoNumeric.options.emptyInputBehavior.always:
+                        valueToSetOnEmpty = '';
+                        break;
+                    case AutoNumeric.options.emptyInputBehavior.min:
+                        valueToSetOnEmpty = this.settings.minimumValue;
+                        break;
+                    case AutoNumeric.options.emptyInputBehavior.max:
+                        valueToSetOnEmpty = this.settings.maximumValue;
+                        break;
                     case AutoNumeric.options.emptyInputBehavior.zero:
                         valueToSetOnEmpty = '0';
                         break;
                     case AutoNumeric.options.emptyInputBehavior.null:
                         valueToSetOnEmpty = null;
                         break;
-                    default :
-                        valueToSetOnEmpty = '';
+                    // When emptyInputBehavior is a number or a string representing a number
+                    default:
+                        valueToSetOnEmpty = this.settings.emptyInputBehavior;
                 }
 
                 this._setRawValue(valueToSetOnEmpty);

--- a/src/AutoNumericOptions.js
+++ b/src/AutoNumericOptions.js
@@ -282,6 +282,8 @@ Object.defineProperty(AutoNumeric, 'options', {
                 focus : 'focus',
                 press : 'press',
                 always: 'always',
+                min   : 'min',
+                max   : 'max',
                 zero  : 'zero',
             },
 

--- a/src/AutoNumericOptions.js
+++ b/src/AutoNumericOptions.js
@@ -274,17 +274,19 @@ Object.defineProperty(AutoNumeric, 'options', {
              * - 'focus'  : The currency sign is displayed when the input receives focus (default)
              * - 'press'  : The currency sign is displayed whenever a key is being pressed
              * - 'always' : The currency sign is always displayed
+             * - 'min'    : The minimum value is displayed if the input has no value on focus out
+             * - 'max'    : The maximum value is displayed if the input has no value on focus out
              * - 'zero'   : A zero is displayed ('rounded' with or without a currency sign) if the input has no value on focus out
              * - 'null'   : When the element is empty, the `rawValue` and the element value/text is set to `null`. This also allows to set the value to `null` using `anElement.set(null)`.
              */
             emptyInputBehavior: {
-                null  : 'null',
                 focus : 'focus',
                 press : 'press',
                 always: 'always',
                 min   : 'min',
                 max   : 'max',
                 zero  : 'zero',
+                null  : 'null',
             },
 
             /* Defines if the custom and native events triggered by AutoNumeric should bubble up or not.

--- a/test/unit/autoNumeric.spec.js
+++ b/test/unit/autoNumeric.spec.js
@@ -1379,15 +1379,30 @@ describe('autoNumeric options and `options.*` methods', () => {
             expect(aNInput.getFormatted()).toEqual('');
             expect(aNInput.getNumber()).toEqual(0);
 
-            aNInput.set('');
+            aNInput.options.reset().french().set('');
             aNInput.options.emptyInputBehavior(AutoNumeric.options.emptyInputBehavior.press);
             expect(aNInput.getFormatted()).toEqual('');
+            aNInput.options.reset().french().set('');
             aNInput.options.emptyInputBehavior(AutoNumeric.options.emptyInputBehavior.focus);
             expect(aNInput.getFormatted()).toEqual('');
+            aNInput.options.reset().french().set('');
             aNInput.options.emptyInputBehavior(AutoNumeric.options.emptyInputBehavior.always);
             expect(aNInput.getFormatted()).toEqual('\u202f€');
+            aNInput.options.reset().french().set('');
+            aNInput.options.emptyInputBehavior(AutoNumeric.options.emptyInputBehavior.min);
+            expect(aNInput.getFormatted()).toEqual('-9.999.999.999.999,99\u202f€');
+            aNInput.options.reset().french().set('');
+            aNInput.options.emptyInputBehavior(AutoNumeric.options.emptyInputBehavior.max);
+            expect(aNInput.getFormatted()).toEqual('9.999.999.999.999,99\u202f€');
+            aNInput.options.reset().french().set('');
             aNInput.options.emptyInputBehavior(AutoNumeric.options.emptyInputBehavior.zero);
             expect(aNInput.getFormatted()).toEqual('0,00\u202f€');
+            aNInput.options.reset().french().set('');
+            aNInput.options.emptyInputBehavior(-1);
+            expect(aNInput.getFormatted()).toEqual('-1,00\u202f€');
+            aNInput.options.reset().french().set('');
+            aNInput.options.emptyInputBehavior('-1');
+            expect(aNInput.getFormatted()).toEqual('-1,00\u202f€');
 
             aNInput.options.reset().french().set(-1234567.89);
             aNInput.options.leadingZero(AutoNumeric.options.leadingZero.deny);
@@ -2241,6 +2256,62 @@ describe('autoNumeric options and `options.*` methods', () => {
                 emptyInputBehavior: AutoNumeric.options.emptyInputBehavior.zero,
                 minimumValue: 0,
                 maximumValue: 0,
+            })).not.toThrow();
+
+            // Un-initialization
+            document.body.removeChild(newInput);
+        });
+
+        it('should fail the validation when a number is used in a range that does not contain this value', () => {
+            spyOn(console, 'warn');
+
+            // Initialization
+            const newInput = document.createElement('input');
+            document.body.appendChild(newInput);
+
+            // minimumValue side
+            expect(() => new AutoNumeric(newInput, {
+                emptyInputBehavior: -1,
+                minimumValue: -2,
+                maximumValue: 10,
+            })).not.toThrow();
+
+            expect(() => new AutoNumeric(newInput, {
+                emptyInputBehavior: -1,
+                minimumValue: -1,
+                maximumValue: 10,
+            })).not.toThrow();
+
+            expect(() => new AutoNumeric(newInput, {
+                emptyInputBehavior: -1,
+                minimumValue: 1,
+                maximumValue: 10,
+            })).toThrow();
+
+            // maximumValue side
+            expect(() => new AutoNumeric(newInput, {
+                emptyInputBehavior: '-1',
+                minimumValue: -10,
+                maximumValue: 1,
+            })).not.toThrow();
+
+            expect(() => new AutoNumeric(newInput, {
+                emptyInputBehavior: '-1',
+                minimumValue: -10,
+                maximumValue: -1,
+            })).not.toThrow();
+
+            expect(() => new AutoNumeric(newInput, {
+                emptyInputBehavior: '-1',
+                minimumValue: -10,
+                maximumValue: -2,
+            })).toThrow();
+
+            // Special case
+            expect(() => new AutoNumeric(newInput, {
+                emptyInputBehavior: '-1',
+                minimumValue: -1,
+                maximumValue: -1,
             })).not.toThrow();
 
             // Un-initialization
@@ -4501,6 +4572,30 @@ describe('Instantiated autoNumeric functions', () => {
             const aNInput = new AutoNumeric(newInput, { emptyInputBehavior : 'zero' }); // Initiate the autoNumeric input
 
             expect(aNInput.getNumericString()).toEqual('0');
+        });
+
+        it('should return number from `emptyInputBehavior` setting as the default value', () => {
+            const newInput = document.createElement('input');
+            document.body.appendChild(newInput);
+            const aNInput = new AutoNumeric(newInput, { emptyInputBehavior : 1 }); // Initiate the autoNumeric input
+
+            expect(aNInput.getNumericString()).toEqual('1');
+        });
+
+        it('should return minimumValue as the default value', () => {
+            const newInput = document.createElement('input');
+            document.body.appendChild(newInput);
+            const aNInput = new AutoNumeric(newInput, { emptyInputBehavior : 'min' }); // Initiate the autoNumeric input
+
+            expect(aNInput.getNumericString()).toEqual('-9999999999999.99');
+        });
+
+        it('should return maximumValue as the default value', () => {
+            const newInput = document.createElement('input');
+            document.body.appendChild(newInput);
+            const aNInput = new AutoNumeric(newInput, { emptyInputBehavior : 'max' }); // Initiate the autoNumeric input
+
+            expect(aNInput.getNumericString()).toEqual('9999999999999.99');
         });
 
         it(`should not return a negative value when inputting a positive one and minimumValue is equal to '0' (cf. issue #284)`, () => {
@@ -7538,6 +7633,11 @@ describe('Static autoNumeric functions', () => {
             expect(() => AutoNumeric.validate({ emptyInputBehavior: 'always' })).not.toThrow();
             expect(() => AutoNumeric.validate({ emptyInputBehavior: 'zero' })).not.toThrow();
             expect(() => AutoNumeric.validate({ emptyInputBehavior: 'null' })).not.toThrow();
+            expect(() => AutoNumeric.validate({ emptyInputBehavior: 'min' })).not.toThrow();
+            expect(() => AutoNumeric.validate({ emptyInputBehavior: 'max' })).not.toThrow();
+            expect(() => AutoNumeric.validate({ emptyInputBehavior: '-5' })).not.toThrow();
+            expect(() => AutoNumeric.validate({ emptyInputBehavior: 5 })).not.toThrow();
+            expect(() => AutoNumeric.validate({ emptyInputBehavior: -5 })).not.toThrow();
 
             expect(() => AutoNumeric.validate({ eventBubbles: true })).not.toThrow();
             expect(() => AutoNumeric.validate({ eventBubbles: false })).not.toThrow();
@@ -7937,9 +8037,6 @@ describe('Static autoNumeric functions', () => {
             expect(() => AutoNumeric.validate({ emptyInputBehavior: true })).toThrow();
             expect(() => AutoNumeric.validate({ emptyInputBehavior: 'foobar' })).toThrow();
             expect(() => AutoNumeric.validate({ emptyInputBehavior: '22foobar' })).toThrow();
-            expect(() => AutoNumeric.validate({ emptyInputBehavior: '-5' })).toThrow();
-            expect(() => AutoNumeric.validate({ emptyInputBehavior: 5 })).toThrow();
-            expect(() => AutoNumeric.validate({ emptyInputBehavior: -5 })).toThrow();
             expect(() => AutoNumeric.validate({ emptyInputBehavior: null })).toThrow();
 
             expect(() => AutoNumeric.validate({ eventBubbles: 0 })).toThrow();

--- a/test/unit/autoNumeric.spec.js
+++ b/test/unit/autoNumeric.spec.js
@@ -1391,18 +1391,23 @@ describe('autoNumeric options and `options.*` methods', () => {
             aNInput.options.reset().french().set('');
             aNInput.options.emptyInputBehavior(AutoNumeric.options.emptyInputBehavior.min);
             expect(aNInput.getFormatted()).toEqual('-9.999.999.999.999,99\u202f€');
+            expect(aNInput.getNumericString()).toEqual('-9999999999999.99');
             aNInput.options.reset().french().set('');
             aNInput.options.emptyInputBehavior(AutoNumeric.options.emptyInputBehavior.max);
             expect(aNInput.getFormatted()).toEqual('9.999.999.999.999,99\u202f€');
+            expect(aNInput.getNumericString()).toEqual('9999999999999.99');
             aNInput.options.reset().french().set('');
             aNInput.options.emptyInputBehavior(AutoNumeric.options.emptyInputBehavior.zero);
             expect(aNInput.getFormatted()).toEqual('0,00\u202f€');
+            expect(aNInput.getNumericString()).toEqual('0');
             aNInput.options.reset().french().set('');
             aNInput.options.emptyInputBehavior(-1);
             expect(aNInput.getFormatted()).toEqual('-1,00\u202f€');
+            expect(aNInput.getNumericString()).toEqual('-1');
             aNInput.options.reset().french().set('');
             aNInput.options.emptyInputBehavior('-1');
             expect(aNInput.getFormatted()).toEqual('-1,00\u202f€');
+            expect(aNInput.getNumericString()).toEqual('-1');
 
             aNInput.options.reset().french().set(-1234567.89);
             aNInput.options.leadingZero(AutoNumeric.options.leadingZero.deny);


### PR DESCRIPTION
This implements https://github.com/autoNumeric/autoNumeric/issues/476.

It allows for `emptyInputBehavior` to be set to `min`, `max`, a number, or a string representing a number, in addition to the previous allowed values of `focus`, `press`, `always`, `null`, and `zero`.