### PR TITLE
TypeScript definitions, another try

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -101,8 +101,17 @@ declare class AutoNumeric {
     saveChangeToHistory?: boolean
   ): void;
 
+  setUnformatted(value: number, options?: Options): void;
 
+  get(callback?: (value: string, instance: AutoNumeric) => void): string;
 
+  getFormatted(
+    callback?: (value: string, instance: AutoNumeric) => void
+  ): string;
+
+  /**
+   * Returns a plain number value without formatting
+   */
   getNumber(
     callback: (value: number | null, instance: AutoNumeric) => void = null
   ): number | null;
@@ -111,11 +120,91 @@ declare class AutoNumeric {
     callback: (value: string | null, instance: AutoNumeric) => void = null
   ): string | null;
 
+  getLocalized(callback: (value: string) => void): string;
+
+  reformat(): void;
+
+  unformat(): void;
+
+  unformatLocalized(forcedOutputFormat?: OutputFormatOption): void;
+
+  isPristine(): boolean;
+
+  select(): void;
+
+  selectNumber(): void;
+
+  selectInteger(): void;
+
+  selectDecimal(): void;
+
+  clear(reset?: boolean): void;
+
+  update(...options: Options[]): Input;
+
   /**
    * Remove the autoNumeric listeners from the element (previous name : 'destroy'). Keep the element content intact.
    */
   remove(): void;
 
+  /**
+   * Remove the autoNumeric listeners from the element, and reset its value to ''
+   */
+  wipe(): void;
+
+  /**
+   * Remove the autoNumeric listeners from the element, and delete the DOM element altogether
+   */
+  nuke(): void;
+
+  /**
+   * Return the DOM element reference of the autoNumeric-managed element
+   */
+  node(): HTMLInputElement;
+
+  parent(): HTMLElement;
+
+  detach(): void;
+
+  attach(otherAnElement: HTMLElement, reFormat?: boolean): void;
+
+  init(domeElement2: HTMLElement): Input;
+
+  form(forcedSearch?: boolean): HTMLFormElement;
+
+  formNumericString(): string;
+
+  formFormatted(): string;
+
+  formLocalized(forcedOutputFormat?: PredefinedLanguages): string;
+
+  formArrayNumericString(): HTMLInputElement[];
+
+  formArrayFormatted(): HTMLInputElement[];
+
+  formArrayLocalized(): HTMLInputElement[];
+
+  formJsonNumericString(): string;
+
+  formJsonFormatted(): string;
+
+  formJsonLocalized(): string;
+
+  formUnformat(): void;
+
+  formReformat(): void;
+
+  formSubmitArrayNumericString(callback: Function): Input;
+
+  formSubmitArrayFormatted(callback: Function): Input;
+
+  formSubmitArrayLocalized(callback: Function): Input;
+
+  formSubmitJsonNumericString(callback: Function): Input;
+
+  formSubmitJsonFormatted(callback: Function): Input;
+
+  formSubmitJsonLocalized(callback: Function): Input;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,99 @@
+/*~ Note that ES6 modules cannot directly export class objects.
+ *~ This file should be imported using the CommonJS-style:
+ *~   import x = require('autonumeric');
+ *~
+ *~ Alternatively, if --allowSyntheticDefaultImports or
+ *~ --esModuleInterop is turned on, this file can also be
+ *~ imported as a default import:
+ *~   import x from 'autonumeric';
+ *~
+ *~ Refer to the TypeScript documentation at
+ *~ https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require
+ *~ to understand common workarounds for this limitation of ES6 modules.
+ */
+ 
+/*~ If this module is a UMD module that exposes a global variable 'myClassLib' when
+ *~ loaded outside a module loader environment, declare that global here:
+ *~ export as namespace myClassLib;
+ */
+
+/* The class constructor function is the exported object from the file */
+export = AutoNumeric;
+
+declare class AutoNumeric {
+  constructor(
+    elementOrSelector: string | HTMLInputElement | HTMLElement,
+    defaultValue: string | number = null,
+    options: AutoNumericOptions | string = null
+  ): Input;
+
+  // someProperty: string[];
+
+  multiple(
+    elementsOrSelector:
+      | string
+      | HTMLElement[]
+      | { rootElement: HTMLElement; exclude?: HTMLInputElement[] },
+    initialValue: number | Array<number | null> = null,
+    options: AutoNumericOptions | AutoNumericOptions[] = null
+  ): Input;
+
+  /**
+   * Set the value, but do not save the new state in the history table (used for undo/redo actions)
+   */
+  set(
+    value: number | string | null,
+    options?: AutoNumericOptions,
+    save?: boolean
+  ): void;
+
+  update(...options: AutoNumericOptions[]): void;
+
+  remove(): void;
+
+  getNumber(
+    callback: (value: number | null, instance: AutoNumeric) => void = null
+  ): number | null;
+
+  getNumericString(
+    callback: (value: string | null, instance: AutoNumeric) => void = null
+  ): string | null;
+
+  static getPredefinedOptions(): AutoNumericOptions;
+}
+
+/* Expose types as well */
+declare namespace AutoNumeric {
+  export type OutputFormat = 'string' | 'number';
+
+  export interface Options {
+    allowDecimalPadding?: boolean | 'floats';
+    suffixText?: string;
+    currencySymbol?: string;
+    currencySymbolPlacement?: string;
+    decimalCharacter?: string;
+    decimalCharacterAlternative?: string | null;
+    decimalPlaces?: number; // 0 or positive integer
+    digitGroupSeparator?: string;
+    emptyInputBehavior?:
+      | 'null'
+      | 'focus'
+      | 'press'
+      | 'always'
+      | 'min'
+      | 'max'
+      | 'zero'
+      | number
+      | string /* representing a number */;
+    modifyValueOnWheel?: boolean;
+    outputFormat?: AutoNumericOutputFormat;
+    readOnly?: boolean;
+    negativePositiveSignPlacement?: 'p';
+    styleRules?: {
+      positive: string;
+      negative: string;
+    };
+    minimumValue?: string;
+    maximumValue?: string;
+  }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -114,28 +114,48 @@ declare class AutoNumeric {
     saveChangeToHistory?: boolean
   ): void;
 
+  /**
+   * Set the given value directly as the DOM element value, without formatting it beforehand.
+   * You can also set the value and update the setting in one go (the value will again not be formatted immediately).
+   */
   setUnformatted(value: number, options?: Options): void;
 
   /**
-    * The get() function is deprecated and should not be used. Omitted from TS def for that reason.
-    * get(callback?: (value: string, instance: AutoNumeric) => void): string;
-    */
+   * The get() function is deprecated and should not be used. Omitted from TS def for that reason.
+   * get(callback?: (value: string, instance: AutoNumeric) => void): string;
+   */
 
+  /**
+   * Return the current formatted value of the AutoNumeric element as a string.
+   */
   getFormatted(
     callback?: (value: string, instance: AutoNumeric) => void
   ): string;
 
   /**
-   * Returns a plain number value without formatting
+   * Return the element unformatted value as a real JavaScript number.
    */
   getNumber(
     callback: (value: number | null, instance: AutoNumeric) => void = null
   ): number | null;
 
+  /**
+   * Return the unformatted value as a string.
+   * This can also return `null` if `rawValue` is null.
+   */
   getNumericString(
     callback?: (value: string | null, instance: AutoNumeric) => void = null
   ): string | null;
 
+  /**
+   * Returns the unformatted value, but following the `outputFormat` setting, which means the output can either be:
+   *
+   * - a string (that could or could not represent a number, ie. "12345,67-"), or
+   * - a plain number (if the setting 'number' is used).
+   *
+   * By default the returned values are an ISO numeric string "1234.56" or "-1234.56" where the decimal character is a period.
+   * Check the `outputFormat` option definition for more details.
+   */
   getLocalized(callback: (value: string) => void): string;
 
   reformat(): void;
@@ -159,17 +179,20 @@ declare class AutoNumeric {
   update(...options: Options[]): Input;
 
   /**
-   * Remove the autoNumeric listeners from the element (previous name : 'destroy'). Keep the element content intact.
+   * Remove the autoNumeric data and event listeners from the element, but keep the element content intact.
+   * This also clears the value from sessionStorage (or cookie, depending on browser supports).
+   * Note: this does not remove the formatting.
    */
   remove(): void;
 
   /**
-   * Remove the autoNumeric listeners from the element, and reset its value to ''
+   * Remove the autoNumeric data and event listeners from the element, and reset its value to the empty string ''.
+   * This also clears the value from sessionStorage (or cookie, depending on browser supports).
    */
   wipe(): void;
 
   /**
-   * Remove the autoNumeric listeners from the element, and delete the DOM element altogether
+   * Remove the autoNumeric data and event listeners from the element, and delete the DOM element altogether
    */
   nuke(): void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,14 +31,14 @@ declare class AutoNumeric {
     options: AutoNumericOptions | string = null
   ): AutoNumeric;
 
-  multiple(
+  static multiple(
     elementsOrSelector:
       | string
       | HTMLElement[]
       | { rootElement: HTMLElement; exclude?: HTMLInputElement[] },
     initialValue: number | Array<number | null> = null,
     options: AutoNumericOptions | AutoNumericOptions[] = null
-  ): Input;
+  ): AutoNumeric[];
 
   /**
    * Set the value, but do not save the new state in the history table (used for undo/redo actions)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,23 +1,27 @@
-/*~ Note that ES6 modules cannot directly export class objects.
- *~ This file should be imported using the CommonJS-style:
- *~   import x = require('autonumeric');
- *~
- *~ Alternatively, if --allowSyntheticDefaultImports or
- *~ --esModuleInterop is turned on, this file can also be
- *~ imported as a default import:
- *~   import x from 'autonumeric';
- *~
- *~ Refer to the TypeScript documentation at
- *~ https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require
- *~ to understand common workarounds for this limitation of ES6 modules.
+/**
+ * Note that ES6 modules cannot directly export class objects.
+ * This file should be imported using the CommonJS-style:
+ *   import x = require('autonumeric');
+ *
+ * Alternatively, if --allowSyntheticDefaultImports or
+ * --esModuleInterop is turned on, this file can also be
+ * imported as a default import:
+ *   import x from 'autonumeric';
+ *
+ * Refer to the TypeScript documentation at
+ * https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require
+ * to understand common workarounds for this limitation of ES6 modules.
  */
  
-/*~ If this module is a UMD module that exposes a global variable 'myClassLib' when
- *~ loaded outside a module loader environment, declare that global here:
- *~ export as namespace myClassLib;
+/**
+ * If this module is a UMD module that exposes a global variable 'myClassLib' when
+ * loaded outside a module loader environment, declare that global here:
+ * export as namespace myClassLib;
  */
 
-/* The class constructor function is the exported object from the file */
+/**
+ * The class constructor function is the exported object from the file
+ */
 export = AutoNumeric;
 
 declare class AutoNumeric {
@@ -62,7 +66,9 @@ declare class AutoNumeric {
   static getPredefinedOptions(): AutoNumericOptions;
 }
 
-/* Expose types as well */
+/**
+ * Expose types as well
+ */
 declare namespace AutoNumeric {
   export type OutputFormat = 'string' | 'number';
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ declare class AutoNumeric {
     elementOrSelector: string | HTMLInputElement | HTMLElement,
     initialValue: string | number = null,
     options: AutoNumericOptions | string = null
-  ): Input;
+  ): AutoNumeric;
 
   multiple(
     elementsOrSelector:

--- a/index.d.ts
+++ b/index.d.ts
@@ -116,7 +116,10 @@ declare class AutoNumeric {
 
   setUnformatted(value: number, options?: Options): void;
 
-  get(callback?: (value: string, instance: AutoNumeric) => void): string;
+  /**
+    * The get() function is deprecated and should not be used. Omitted from TS def for that reason.
+    * get(callback?: (value: string, instance: AutoNumeric) => void): string;
+    */
 
   getFormatted(
     callback?: (value: string, instance: AutoNumeric) => void

--- a/index.d.ts
+++ b/index.d.ts
@@ -136,7 +136,7 @@ declare class AutoNumeric {
    * Return the element unformatted value as a real JavaScript number.
    */
   getNumber(
-    callback: (value: number | null, instance: AutoNumeric) => void = null
+    callback?: (value: number | null, instance: AutoNumeric) => void = null
   ): number | null;
 
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -117,7 +117,7 @@ declare class AutoNumeric {
   ): number | null;
 
   getNumericString(
-    callback: (value: string | null, instance: AutoNumeric) => void = null
+    callback?: (value: string | null, instance: AutoNumeric) => void = null
   ): string | null;
 
   getLocalized(callback: (value: string) => void): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,12 +14,6 @@
  */
  
 /**
- * If this module is a UMD module that exposes a global variable 'myClassLib' when
- * loaded outside a module loader environment, declare that global here:
- * export as namespace myClassLib;
- */
-
-/**
  * The class constructor function is the exported object from the file
  */
 export = AutoNumeric;

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ export = AutoNumeric;
 declare class AutoNumeric {
   constructor(
     elementOrSelector: string | HTMLInputElement | HTMLElement,
-    defaultValue: string | number = null,
+    initialValue: string | number = null,
     options: AutoNumericOptions | string = null
   ): Input;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -156,6 +156,7 @@ declare class AutoNumeric {
    * By default the returned values are an ISO numeric string "1234.56" or "-1234.56" where the decimal character is a period.
    * Check the `outputFormat` option definition for more details.
    */
+  getLocalized(forcedOutputFormat?: OutputFormatOption, callback?: (value: string) => void): string;
   getLocalized(callback: (value: string) => void): string;
 
   reformat(): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -171,6 +171,9 @@ declare class AutoNumeric {
 
   clear(reset?: boolean): void;
 
+  /**
+   * Updates the AutoNumeric settings, and immediately format the element accordingly.
+   */
   update(...options: Options[]): Input;
 
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,9 +41,56 @@ declare class AutoNumeric {
   ): AutoNumeric[];
 
   /**
+   * Return true in the settings are valid
+   */
+  static areSettingsValid(options: Options): boolean;
+
+  /**
+   * Format the given number with the given options. This returns the formatted value as a string.
+   */
+  static format(value: number | string | HTMLElement, options: Options): string;
+
+  /**
+   * Format the domElement value with the given options and returns the formatted value as a string.
+   */
+  static formatAndSet(domElement: HTMLElement, options: Options): string;
+
+  /**
+   * Return the AutoNumeric object that manages the given DOM element
+   */
+  static getAutoNumericElement(domElement: HTMLElement): Input;
+
+  /**
+   * Return the default autoNumeric settings
+   */
+  static getDefaultConfig(): Options;
+
+  /**
    * Return all the predefined options in one object
    */
   static getPredefinedOptions(): PredefinedOptions;
+
+  /**
+   * Return true if the given DOM element has an AutoNumeric object that manages it.
+   */
+  static isManagedByAutoNumeric(domElement: HTMLElement): boolean;
+
+  /**
+   * Unformat and localize the given formatted string with the given options.
+   */
+  static localize(value: string | HTMLElement, options: Options): string;
+
+  static localizeAndSet(domElement: HTMLElement, options: Options): string;
+
+  static mergeOptions(...options: Options[]): Options;
+
+  static reformatAndSet(referenceToTheDomElement: HTMLElement): void;
+
+  static test(domElement: HTMLElement): boolean;
+
+  static validate(options: Options): boolean;
+
+  static version(): string;
 
   /**
    * Set the value, but do not save the new state in the history table (used for undo/redo actions)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,12 @@
 /**
  * Note that ES6 modules cannot directly export class objects.
  * This file should be imported using the CommonJS-style:
- *   import x = require('autonumeric');
+ *   import AutoNumeric = require('autonumeric');
  *
  * Alternatively, if --allowSyntheticDefaultImports or
  * --esModuleInterop is turned on, this file can also be
  * imported as a default import:
- *   import x from 'autonumeric';
+ *   import AutoNumeric from 'autonumeric';
  *
  * Refer to the TypeScript documentation at
  * https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require

--- a/index.d.ts
+++ b/index.d.ts
@@ -267,7 +267,9 @@ declare namespace AutoNumeric {
     | "decimalLeft"
     | "decimalRight"
     | "doNoForceCaretPosition";
+
   export type CurrencySymbolPlacementOption = "p" | "s";
+
   export type EmptyInputBehaviorOption =
     | "null"
     | "focus"
@@ -278,24 +280,29 @@ declare namespace AutoNumeric {
     | "zero"
     | number
     | string /* representing a number */;
+
   export type LeadingZeroOption = "allow" | "deny" | "keep";
+
   export type NegativePositiveSignPlacementOption =
     | "p"
     | "s"
     | "l"
     | "r"
     | null;
+
   export type OnInvalidPasteOption =
     | "error"
     | "ignore"
     | "clamp"
     | "truncate"
     | "replace";
+
   export type OverrideMinMaxLimitsOption =
     | "ceiling"
     | "floor"
     | "ignore"
     | null;
+
   export type RoundingMethodOption =
     | "S"
     | "A"
@@ -310,6 +317,7 @@ declare namespace AutoNumeric {
     | "CHF"
     | "U05"
     | "D05";
+
   export type SerializeSpacesOption = "+" | "%20";
 
   export interface Options {

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,8 +31,6 @@ declare class AutoNumeric {
     options: AutoNumericOptions | string = null
   ): Input;
 
-  // someProperty: string[];
-
   multiple(
     elementsOrSelector:
       | string

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,7 @@ declare class AutoNumeric {
   constructor(
     elementOrSelector: string | HTMLInputElement | HTMLElement,
     initialValue: string | number = null,
-    options: AutoNumericOptions | string = null
+    options: Options | string = null
   ): AutoNumeric;
 
   static multiple(
@@ -37,19 +37,23 @@ declare class AutoNumeric {
       | HTMLElement[]
       | { rootElement: HTMLElement; exclude?: HTMLInputElement[] },
     initialValue: number | Array<number | null> = null,
-    options: AutoNumericOptions | AutoNumericOptions[] = null
+    options: Options | Options[] = null
   ): AutoNumeric[];
+
+  /**
+   * Return all the predefined options in one object
+   */
+  static getPredefinedOptions(): PredefinedOptions;
 
   /**
    * Set the value, but do not save the new state in the history table (used for undo/redo actions)
    */
   set(
     value: number | string | null,
-    options?: AutoNumericOptions,
+    options?: Options,
     saveChangeToHistory?: boolean
   ): void;
 
-  update(...options: AutoNumericOptions[]): void;
 
   remove(): void;
 
@@ -61,7 +65,6 @@ declare class AutoNumeric {
     callback: (value: string | null, instance: AutoNumeric) => void = null
   ): string | null;
 
-  static getPredefinedOptions(): AutoNumericOptions;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -102,7 +102,6 @@ declare class AutoNumeric {
   ): void;
 
 
-  remove(): void;
 
   getNumber(
     callback: (value: number | null, instance: AutoNumeric) => void = null
@@ -111,6 +110,11 @@ declare class AutoNumeric {
   getNumericString(
     callback: (value: string | null, instance: AutoNumeric) => void = null
   ): string | null;
+
+  /**
+   * Remove the autoNumeric listeners from the element (previous name : 'destroy'). Keep the element content intact.
+   */
+  remove(): void;
 
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -46,7 +46,7 @@ declare class AutoNumeric {
   set(
     value: number | string | null,
     options?: AutoNumericOptions,
-    save?: boolean
+    saveChangeToHistory?: boolean
   ): void;
 
   update(...options: AutoNumericOptions[]): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -515,6 +515,7 @@ declare namespace AutoNumeric {
     Japanese: Partial<Options>;
     Chinese: Partial<Options>;
     Brazilian: Partial<Options>;
+    Turkish: Partial<Options>;
   }
 
   type PredefinedOptions = Partial<Options> & PredefinedLanguages;

--- a/index.d.ts
+++ b/index.d.ts
@@ -93,7 +93,20 @@ declare class AutoNumeric {
   static version(): string;
 
   /**
-   * Set the value, but do not save the new state in the history table (used for undo/redo actions)
+   * Set the given element value, and format it immediately.
+   * Additionally, this `set()` method can accept options that will be merged into the current AutoNumeric element, taking precedence over any previous settings.
+   *
+   * @example anElement.set('12345.67') // Formats the value
+   * @example anElement.set(12345.67) // Formats the value
+   * @example anElement.set(12345.67, { decimalCharacter : ',' }) // Update the settings and formats the value in one go
+   * @example anElement.northAmerican().set('$12,345.67') // Set an already formatted value (this does not _exactly_ respect the currency symbol/negative placements, but only remove all non-numbers characters, according to the ones given in the settings)
+   * @example anElement.set(null) // Set the rawValue and element value to `null`
+   *
+   * @param {number|string|null} newValue The value must be a Number, a numeric string or `null` (if `emptyInputBehavior` is set to `'null'`)
+   * @param {object} options A settings object that will override the current settings. Note: the update is done only if the `newValue` is defined.
+   * @param {boolean} saveChangeToHistory If set to `true`, then the change is recorded in the history table
+   * @returns {AutoNumeric}
+   * @throws
    */
   set(
     value: number | string | null,

--- a/index.d.ts
+++ b/index.d.ts
@@ -211,36 +211,264 @@ declare class AutoNumeric {
  * Expose types as well
  */
 declare namespace AutoNumeric {
-  export type OutputFormat = 'string' | 'number';
+  export type OutputFormatOption =
+    | "string"
+    | "number"
+    | "."
+    | "-."
+    | ","
+    | "-,"
+    | ".-"
+    | ",-"
+    | null;
+
+  export type CaretPositionOption =
+    | "start"
+    | "end"
+    | "decimalLeft"
+    | "decimalRight"
+    | "doNoForceCaretPosition";
+  export type CurrencySymbolPlacementOption = "p" | "s";
+  export type EmptyInputBehaviorOption =
+    | "null"
+    | "focus"
+    | "press"
+    | "always"
+    | "min"
+    | "max"
+    | "zero"
+    | number
+    | string /* representing a number */;
+  export type LeadingZeroOption = "allow" | "deny" | "keep";
+  export type NegativePositiveSignPlacementOption =
+    | "p"
+    | "s"
+    | "l"
+    | "r"
+    | null;
+  export type OnInvalidPasteOption =
+    | "error"
+    | "ignore"
+    | "clamp"
+    | "truncate"
+    | "replace";
+  export type OverrideMinMaxLimitsOption =
+    | "ceiling"
+    | "floor"
+    | "ignore"
+    | null;
+  export type RoundingMethodOption =
+    | "S"
+    | "A"
+    | "s"
+    | "a"
+    | "B"
+    | "U"
+    | "D"
+    | "C"
+    | "F"
+    | "N05"
+    | "CHF"
+    | "U05"
+    | "D05";
+  export type SerializeSpacesOption = "+" | "%20";
 
   export interface Options {
-    allowDecimalPadding?: boolean | 'floats';
-    suffixText?: string;
+    /**
+     * Allow padding the decimal places with zeros.
+     * @default true
+     */
+    allowDecimalPadding?: boolean | "floats";
+
+    /**
+     * Determine where should be positioned the caret on focus
+     * @default null
+     */
+    caretPositionOnFocus?: CaretPositionOption;
+
+    /**
+     * Determine if a local list of AutoNumeric objects must be kept when initializing the elements and others
+     * @default true
+     */
+    createLocalList?: boolean;
+
+    /**
+     * Currency symbol
+     * @default ''
+     */
     currencySymbol?: string;
-    currencySymbolPlacement?: string;
+
+    /**
+     * Placement of the currency sign, relative to the number (as a prefix or a suffix)
+     * @default 'p'
+     */
+    currencySymbolPlacement?: CurrencySymbolPlacementOption;
+    /**
+     * Decimal separator character
+     * @default '.'
+     */
     decimalCharacter?: string;
+
+    /**
+     * Allow to declare alternative decimal separator which is automatically replaced by the real decimal character
+     * @default null
+     */
     decimalCharacterAlternative?: string | null;
-    decimalPlaces?: number; // 0 or positive integer
+
+    /**
+     * Defines the default number of decimal places to show on the formatted value, and to keep as the precision for the rawValue
+     * 0 or positive integer
+     * @default 2
+     */
+    decimalPlaces?: number;
+
+    /**
+     * Defines how many decimal places should be kept for the raw value.
+     * @default null
+     */
+    decimalPlacesRawValue?: number | null;
+
+    /**
+     * The number of decimal places to show when unfocused
+     * @default null
+     */
+    decimalPlacesShownOnBlur?: number | null;
+
+    /**
+     * The number of decimal places to show when focused
+     * @default null
+     */
+    decimalPlacesShownOnFocus?: number | null;
+
+    /**
+     * Helper option for ASP.NET postback
+     * This should be set as the value of the unformatted default value
+     * examples:
+     * no default value="" {defaultValueOverride: ""}
+     * value=1234.56 {defaultValueOverride: '1234.56'}
+     * @default null
+     */
+    defaultValueOverride?: string | { doNotOverride: null };
+
+    /**
+     * Digital grouping for the thousand separator
+     * @default '3'
+     */
+    digitalGroupSpacing?: string;
+
+    /**
+     * Thousand separator character
+     * @default ','
+     */
     digitGroupSeparator?: string;
-    emptyInputBehavior?:
-      | 'null'
-      | 'focus'
-      | 'press'
-      | 'always'
-      | 'min'
-      | 'max'
-      | 'zero'
-      | number
-      | string /* representing a number */;
-    modifyValueOnWheel?: boolean;
-    outputFormat?: AutoNumericOutputFormat;
-    readOnly?: boolean;
-    negativePositiveSignPlacement?: 'p';
-    styleRules?: {
-      positive: string;
-      negative: string;
-    };
-    minimumValue?: string;
+
+    /**
+     * Define the number that will divide the current value shown when unfocused
+     * @default null
+     */
+    divisorWhenUnfocused?: number | null;
+
+    emptyInputBehavior?: EmptyInputBehaviorOption;
+
+    failOnUnknownOption?: boolean;
+
+    formatOnPageLoad?: boolean;
+
+    historySize?: number;
+
+    isCancellable?: boolean;
+
+    leadingZero?: LeadingZeroOption;
+
     maximumValue?: string;
+
+    minimumValue?: string;
+
+    /**
+     * Determine if the element value can be incremented / decremented with the mouse wheel.
+     */
+
+    modifyValueOnWheel?: boolean;
+
+    negativeBracketsTypeOnBlur?: string | null;
+
+    /**
+     * Placement of negative/positive sign relative to the currency symbol (possible options are l (left), r (right), p (prefix) and s (suffix))
+     * @default null
+     */
+    negativePositiveSignPlacement?: NegativePositiveSignPlacementOption;
+
+    noEventListeners?: boolean;
+
+    onInvalidPaste?: OnInvalidPasteOption;
+
+    outputFormat?: OutputFormatOption;
+
+    overrideMinMaxLimits?: OverrideMinMaxLimitsOption;
+
+    rawValueDivisor?: number | null;
+
+    readOnly?: boolean;
+
+    roundingMethod?: RoundingMethodOption;
+
+    saveValueToSessionStorage?: boolean;
+
+    selectNumberOnly?: boolean;
+
+    selectOnFocus?: boolean;
+
+    serializeSpaces?: SerializeSpacesOption;
+
+    showOnlyNumbersOnFocus?: boolean;
+
+    showPositiveSign?: boolean;
+
+    showWarnings?: boolean;
+
+    // FIXME
+    styleRules?: {
+      positive?: string | null;
+      negative?: string;
+      ranges?: Array<{
+        min: number;
+        max: number;
+        class: string;
+      }>;
+      userDefined?: Array<
+        | {
+            callback: (rawValue: number) => boolean;
+            classes: [string] | [string, string];
+          }
+        | {
+            callback: (rawValue: number) => number | number[] | null;
+            classes: string[];
+          }
+        | { callback: (autoNumericInstance: AutoNumeric) => void }
+      >;
+    } | null;
+
+    suffixText?: string;
+
+    symbolWhenUnfocused?: string | null;
+
+    unformatOnHover?: boolean;
+
+    unformatOnSubmit?: boolean;
+
+    wheelStep?: number | "progressive";
   }
+
+  interface PredefinedLanguages {
+    French: Partial<Options>;
+    Spanish: Partial<Options>;
+    NorthAmerican: Partial<Options>;
+    British: Partial<Options>;
+    Swiss: Partial<Options>;
+    Japanese: Partial<Options>;
+    Chinese: Partial<Options>;
+    Brazilian: Partial<Options>;
+  }
+
+  type PredefinedOptions = Partial<Options> & PredefinedLanguages;
 }

--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -8713,8 +8713,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
     /**
      * Process deletion of characters when the minus sign is to the right of the numeric characters.
      *
-     * @param {string} left The part on the left of the caret or selection
-     * @param {string} right The part on the right of the caret or selection
+     * @param {[string, string]} [left, right] The part on the left and on the right of the caret or selection
      * @returns {[string, string]}
      * @private
      */

--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -8713,8 +8713,8 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
     /**
      * Process deletion of characters when the minus sign is to the right of the numeric characters.
      *
-     * @param {[string, string]} [left, right] The part on the left and on the right of the caret or selection
-     * @returns {[string, string]}
+     * @param {string[]} leftAndRight The parts on the left and on the right of the caret or selection as an array with [left, right]
+     * @returns {string[]} Processed left and right as an array with [left, right]
      * @private
      */
     _processCharacterDeletionIfTrailingNegativeSign([left, right]) {


### PR DESCRIPTION
Another try for TypeScript definitions, after #531 and <https://gist.github.com/chadbengen/7a3b696789b4af73b6be9ee4ccdbf05d>

We have primarily added definitions for the parts we're using, so many methods and options are missing at the moment. But this IMO shouldn't be a blocker since it is a good starting point for others to contribute for methods/options they're using and there shouldn't be any regression for anyone using autoNumeric with TS at the moment (most probably using autoNumeric as a typeless black-box via `declare module 'autonumeric'`)

Some more notes:

- in contrast to previous attempts, this one tries to properly follow the TS [recommendation for class definitions](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-class-d-ts.html) by using `declare class`
- some of @AlexandreBonneau comments at #531 regarding constructor and `multiple()` have been addressed

We're very interested in getting this merged, so we're eager for your feedback!

(Edit: typos)
