### PR TITLE
Add isWheelEvent helper, update isWheelUpEvent and isWheelDownEvent

### DIFF
--- a/src/AutoNumericHelper.js
+++ b/src/AutoNumericHelper.js
@@ -791,13 +791,24 @@ export default class AutoNumericHelper {
     }
 
     /**
+     * Return `true` if the given event is an instance of WheelEvent
+     *
+     * @static
+     * @param {event} event The event to test
+     * @returns {boolean} Return `true` if the event is an instance of WheelEvent, FALSE otherwise
+    */
+    static isWheelEvent(event) {
+        return event instanceof WheelEvent;
+    }
+
+    /**
      * Return `true` if the given event is a wheelup event
      *
      * @param {WheelEvent} wheelEvent
      * @returns {boolean}
      */
     static isWheelUpEvent(wheelEvent) {
-        if (!wheelEvent.deltaY) {
+        if (!this.isWheelEvent(wheelEvent) || this.isUndefinedOrNullOrEmpty(wheelEvent.deltaY)) {
             this.throwError(`The event passed as a parameter is not a valid wheel event, '${wheelEvent.type}' given.`);
         }
 
@@ -811,7 +822,7 @@ export default class AutoNumericHelper {
      * @returns {boolean}
      */
     static isWheelDownEvent(wheelEvent) {
-        if (!wheelEvent.deltaY) {
+        if (!this.isWheelEvent(wheelEvent) || this.isUndefinedOrNullOrEmpty(wheelEvent.deltaY)) {
             this.throwError(`The event passed as a parameter is not a valid wheel event, '${wheelEvent.type}' given.`);
         }
 


### PR DESCRIPTION
Fix for:
[https://github.com/autoNumeric/autoNumeric/issues/641](https://github.com/autoNumeric/autoNumeric/issues/641)

If event is not an instance of `WheelEvent`, and value of `wheelEvent.deltaY` is `undefined`, `null`, or `empty` then throw error.

This change will not throw an error when scrolling with the trackpad goes x-axis, and allows returning a `false` if `deltaY` is `-0`.