### PR TITLE
Remove Node 6 from Travis test runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: node_js
 
 node_js:
- - "6"
  - "8"
  - "10"
  - "12"


### PR DESCRIPTION
Node 6 is not supported by `@wdio/cli` (5.12.5), which requires at least Node 8.11.

See for example: https://travis-ci.org/autoNumeric/autoNumeric/jobs/657283380?utm_medium=notification&utm_source=github_status

```
node --version

v6.17.1

$ npm --version

3.10.10

$ nvm --version

0.35.2

$ yarn --version

1.15.2

22.57s$ yarn --frozen-lockfile

yarn install v1.15.2

[1/4] Resolving packages...

[2/4] Fetching packages...

info fsevents@1.2.9: The platform "linux" is incompatible with this module.

info "fsevents@1.2.9" is an optional dependency and failed compatibility check. Excluding it from installation.

error @wdio/cli@5.12.5: The engine "node" is incompatible with this module. Expected version ">= 8.11.0". Got "6.17.1"

error Found incompatible module

info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

The command "eval yarn --frozen-lockfile " failed. Retrying, 2 of 3.
```