### PR TITLE
Changed "On Error" and "On Reset Error" callback functions.

### DIFF
--- a/src/AutoNumericDefaultSettings.js
+++ b/src/AutoNumericDefaultSettings.js
@@ -73,7 +73,9 @@ AutoNumeric.defaultSettings = {
     negativeSignCharacter        : AutoNumeric.options.negativeSignCharacter.hyphen,
     noEventListeners             : AutoNumeric.options.noEventListeners.addEvents,
     //TODO Shouldn't we use `truncate` as the default value?
+    onErrorCallback              : () => {},
     onInvalidPaste               : AutoNumeric.options.onInvalidPaste.error,
+    onResetErrorCallback         : () => {},
     outputFormat                 : AutoNumeric.options.outputFormat.none,
     overrideMinMaxLimits         : AutoNumeric.options.overrideMinMaxLimits.doNotOverride,
     positiveSignCharacter        : AutoNumeric.options.positiveSignCharacter.plus,

--- a/src/AutoNumericHelper.js
+++ b/src/AutoNumericHelper.js
@@ -774,7 +774,8 @@ export default class AutoNumericHelper {
      * @throws
      */
     static throwError(message) {
-        throw new Error(message);
+        console.log('%c '+message, 'background: red; color: white; display: block;');
+        //throw new Error(message);
     }
 
     /**


### PR DESCRIPTION
Some error messages which relate to user input should be displayed to the user's in his User Interface, those can be displayed by callback functions on the error occurrence ( for e.g. entering of characters or bypassing mix/max limits ), those can be done by using the callback functions as follows.

```
new AutoNumeric("#element_id",{
          onErrorCallback: (message) => { displayErrorMsg(message) },
          onResetErrorCallback: () => { resetErorrMsg() },
});
```