### PR TITLE
Fix #684 caret always set far right when deleting or inserting number…

### DIFF
--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -9156,7 +9156,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
             if (this.settings.currencySymbolPlacement === AutoNumeric.options.currencySymbolPlacement.suffix) {
                 leftReg = new RegExp(`^.*?${leftAr.join('.*?')}`);
             } else { // prefix is assumed
-                leftReg = new RegExp(`^.*?${this.settings.currencySymbol}${leftAr.join('.*?')}`); // Fixes issue #647 when using a currency that has some characters in it that matches the value we just entered (ie. numbers in the currency)
+                leftReg = new RegExp(`^.*?[${this.settings.currencySymbol}]${leftAr.join('.*?')}`); // Fixes issue #647 when using a currency that has some characters in it that matches the value we just entered (ie. numbers in the currency)
             }
 
             // Search cursor position in formatted value


### PR DESCRIPTION
- This PR fixes issue 684 https://github.com/autoNumeric/autoNumeric/issues/684
- Issue was a dollar sign gets passed as this.settings.currencySymbol - this is obviously bad unescaped/unintended inside a regex