### PR TITLE
Fix undo/redo not firing input event

### DIFF
--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -6740,6 +6740,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
                 // Redo
                 e.preventDefault();
                 this._historyTableRedo();
+                this._triggerEvent(AutoNumeric.events.native.input, e.target);
                 this.onGoingRedo = true;
 
                 return;
@@ -6751,6 +6752,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
                     e.preventDefault();
                     // Undo
                     this._historyTableUndo();
+                    this._triggerEvent(AutoNumeric.events.native.input, e.target);
 
                     return;
                 }


### PR DESCRIPTION
As described in https://github.com/autoNumeric/autoNumeric/issues/720, native `input` event is not being fired when using keyboard shortcuts for undo and redo.