### PR TITLE
Add default export to modules

### DIFF
--- a/src/AutoNumericDefaultSettings.js
+++ b/src/AutoNumericDefaultSettings.js
@@ -100,3 +100,5 @@ AutoNumeric.defaultSettings = {
 
 Object.freeze(AutoNumeric.defaultSettings);
 Object.defineProperty(AutoNumeric, 'defaultSettings', { configurable: false, writable: false });
+
+export default {}

--- a/src/AutoNumericDefaultSettings.js
+++ b/src/AutoNumericDefaultSettings.js
@@ -101,4 +101,4 @@ AutoNumeric.defaultSettings = {
 Object.freeze(AutoNumeric.defaultSettings);
 Object.defineProperty(AutoNumeric, 'defaultSettings', { configurable: false, writable: false });
 
-export default {}
+export default {};

--- a/src/AutoNumericEvents.js
+++ b/src/AutoNumericEvents.js
@@ -53,3 +53,5 @@ AutoNumeric.events = {
 Object.freeze(AutoNumeric.events.native);
 Object.freeze(AutoNumeric.events);
 Object.defineProperty(AutoNumeric, 'events', { configurable: false, writable: false });
+
+export default {}

--- a/src/AutoNumericEvents.js
+++ b/src/AutoNumericEvents.js
@@ -54,4 +54,4 @@ Object.freeze(AutoNumeric.events.native);
 Object.freeze(AutoNumeric.events);
 Object.defineProperty(AutoNumeric, 'events', { configurable: false, writable: false });
 
-export default {}
+export default {};

--- a/src/AutoNumericOptions.js
+++ b/src/AutoNumericOptions.js
@@ -904,4 +904,4 @@ function freezeOptions(options) {
 freezeOptions(AutoNumeric.options);
 Object.defineProperty(AutoNumeric, 'options', { configurable: false, writable: false });
 
-export default {}
+export default {};

--- a/src/AutoNumericOptions.js
+++ b/src/AutoNumericOptions.js
@@ -903,3 +903,5 @@ function freezeOptions(options) {
 
 freezeOptions(AutoNumeric.options);
 Object.defineProperty(AutoNumeric, 'options', { configurable: false, writable: false });
+
+export default {}

--- a/src/AutoNumericPredefinedOptions.js
+++ b/src/AutoNumericPredefinedOptions.js
@@ -234,3 +234,5 @@ Object.getOwnPropertyNames(AutoNumeric.predefinedOptions).forEach(optionName => 
 });
 Object.freeze(AutoNumeric.predefinedOptions);
 Object.defineProperty(AutoNumeric, 'predefinedOptions', { configurable: false, writable: false });
+
+export default {}

--- a/src/AutoNumericPredefinedOptions.js
+++ b/src/AutoNumericPredefinedOptions.js
@@ -235,4 +235,4 @@ Object.getOwnPropertyNames(AutoNumeric.predefinedOptions).forEach(optionName => 
 Object.freeze(AutoNumeric.predefinedOptions);
 Object.defineProperty(AutoNumeric, 'predefinedOptions', { configurable: false, writable: false });
 
-export default {}
+export default {};


### PR DESCRIPTION
We are using `autoNumeric` in combination with Vitejs. In our Storybook build we get the following error.

```
✘ [ERROR] No matching export in "../../../node_modules/autonumeric/src/AutoNumericOptions.js" for import "default"

    ../../../node_modules/autonumeric/src/AutoNumericDefaultSettings.js:31:7:
      31 │ import AutoNumericOptions from './AutoNumericOptions';
         ╵        ~~~~~~~~~~~~~~~~~~
```

The cause of the problem is that `main.js` imports modules that do not export anything. This PR adds empty default exports to the modules.