### PR TITLE
Fix Cut event handling when `eventKey` is being guessed inaccurately

### DIFF
--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -6801,7 +6801,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
         }
 
         // Manage the Cut event
-        if ((e.ctrlKey || e.metaKey) && this.eventKey === AutoNumericEnum.keyName.x) {
+        if ((e.ctrlKey || e.metaKey) && (this.eventKey === AutoNumericEnum.keyName.X || this.eventKey === AutoNumericEnum.keyName.x)) {
             // Save the caret position at the start of the selection
             const caretPosition = AutoNumericHelper.getElementSelection(this.domElement).start;
             // Convert the remaining 'formatted' numbers in a Js number


### PR DESCRIPTION
Under some circumstances, `eventKey` is being guessed inaccurately, for example when running Chrome with a debugger attached (`isSeleniumBot()` returns `true`). In those cases, `eventKey` can be populated with the uppercase variant of the key, causing a comparison that handles the cut event to fail.

This PR fixes this by changing the comparison to include the upper case key variant (which is what the same `_onKeyup` function already does for some other events).