### PR TITLE
Fixes #795 Error when resetting a form that has an input with name="id"

### DIFF
--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -3148,7 +3148,7 @@ export default class AutoNumeric {
             return [];
         }
         const elementsInside = [...formElement.querySelectorAll('[contenteditable=true]')];
-        const elementsOutside = [...document.querySelectorAll(`*:not(input)[form=${formElement.id}][contenteditable=true]`)];
+        const elementsOutside = [...document.querySelectorAll(`*:not(input)[form=${formElement.getAttribute('id')}][contenteditable=true]`)];
 
         return AutoNumericHelper.arrayUnique(elementsInside, elementsOutside);
     }


### PR DESCRIPTION
`formElement.id` is supposed to return the string id of the form. But when resetting a form that has an `<input name="id">`, the `formElement.id` returns the <input> element instead of the id of the form.

This solves #795 