### PR TITLE
Fixes #673 Handle composition events to fix strange behavior during input composition

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
         console       : true,
         CustomEvent   : true,
         WheelEvent    : true,
+        KeyboardEvent : true,
         __dirname     : true,
     },
     extends      : 'eslint:recommended',


### PR DESCRIPTION
Added event listeners for composition events and handling these events to ensure proper formatting during IME (Input Method Editor) input.

This fixes #673.