### PR TITLE
Modify globalObject in webpack configs to 'globalThis' to fix issue #727

### DIFF
--- a/config/webpack.config.base.js
+++ b/config/webpack.config.base.js
@@ -26,7 +26,7 @@ module.exports = {
         library      : 'AutoNumeric',
         filename     : 'autoNumeric.js',
         path         : resolve('dist'),
-        globalObject : 'this',
+        globalObject : 'globalThis',
     },
     resolve: {
         extensions: [

--- a/config/webpack.config.prd.js
+++ b/config/webpack.config.prd.js
@@ -83,7 +83,7 @@ const webpackConfig = merge(baseWebpackConfig, {
         library      : 'AutoNumeric',
         filename     : 'autoNumeric.min.js',
         path         : resolve('dist'),
-        globalObject : 'this',
+        globalObject: 'globalThis',
     },
     plugins: [
         new ESLintPlugin(),

--- a/config/webpack.config.prd.js
+++ b/config/webpack.config.prd.js
@@ -83,7 +83,7 @@ const webpackConfig = merge(baseWebpackConfig, {
         library      : 'AutoNumeric',
         filename     : 'autoNumeric.min.js',
         path         : resolve('dist'),
-        globalObject: 'globalThis',
+        globalObject : 'globalThis',
     },
     plugins: [
         new ESLintPlugin(),


### PR DESCRIPTION
So that the generated bundle can be used in more contexts (import as module in a browser, node.js) 
For further detaiils see https://github.com/autoNumeric/autoNumeric/issues/727