### PR TITLE
fix watching external changes on other than input element, reenable/improve some unit tests

### DIFF
--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -209,7 +209,7 @@ export default class AutoNumeric {
         // Watch any external changes to the element value/textContent/nodeValue and `set()` the new value so that it gets formatted/saved in the history
         this.internalModification = false; // This is temporarily set to `true` only when the AutoNumeric object does update the element value
         this.attributeToWatch = this._getAttributeToWatch();
-        this.getterSetter = Object.getOwnPropertyDescriptor(this.domElement.__proto__, this.attributeToWatch);
+        this.getterSetter = AutoNumericHelper.getGetterSetter(this.domElement, this.attributeToWatch);  // Object.getOwnPropertyDescriptor(this.domElement.__proto__, this.attributeToWatch);
         this._addWatcher();
 
         if (this.settings.createLocalList) {

--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -209,7 +209,7 @@ export default class AutoNumeric {
         // Watch any external changes to the element value/textContent/nodeValue and `set()` the new value so that it gets formatted/saved in the history
         this.internalModification = false; // This is temporarily set to `true` only when the AutoNumeric object does update the element value
         this.attributeToWatch = this._getAttributeToWatch();
-        this.getterSetter = AutoNumericHelper.getGetterSetter(this.domElement, this.attributeToWatch);  // Object.getOwnPropertyDescriptor(this.domElement.__proto__, this.attributeToWatch);
+        this.getterSetter = AutoNumericHelper.getGetterSetter(this.domElement, this.attributeToWatch);
         this._addWatcher();
 
         if (this.settings.createLocalList) {

--- a/src/AutoNumericHelper.js
+++ b/src/AutoNumericHelper.js
@@ -1506,11 +1506,19 @@ export default class AutoNumericHelper {
         return key;
     }
 
+    /**
+     * Returns the object `obj` property 'propertyName', or `null` if the property is not found
+     *
+     * @param {object} obj
+     * @param {string|number} propertyName
+     * @returns {*|null}
+     */
     static getGetterSetter(obj, propertyName) {
-        while ((obj = Object.getPrototypeOf(obj))) {  // double () to make eslint happy
+        while ((obj = Object.getPrototypeOf(obj))) { // double () to make eslint happy
             const descriptor = Object.getOwnPropertyDescriptor(obj, propertyName);
             if (descriptor) return descriptor;
         }
+
         return null;
     }
 

--- a/src/AutoNumericHelper.js
+++ b/src/AutoNumericHelper.js
@@ -1506,6 +1506,14 @@ export default class AutoNumericHelper {
         return key;
     }
 
+    static getGetterSetter(obj, propertyName) {
+        while ((obj = Object.getPrototypeOf(obj))) {  // double () to make eslint happy
+            const descriptor = Object.getOwnPropertyDescriptor(obj, propertyName);
+            if (descriptor) return descriptor;
+        }
+        return null;
+    }
+
     /**
      * Insert the single character `char` in the string `str` at the given position `index`
      *

--- a/test/unit/autoNumeric.spec.js
+++ b/test/unit/autoNumeric.spec.js
@@ -1561,10 +1561,6 @@ describe('autoNumeric options and `options.*` methods', () => {
                     return event;
                 },
             };
-
-            // Event listeners should be added after customFunction.testingFunc has been 'decorated' by the spyOn API
-            // form.addEventListener('click', customFunction.testingFunc);
-            // input.addEventListener('click', customFunction.testingFunc);
         });
 
         afterEach(() => { // Un-initialization
@@ -1573,7 +1569,7 @@ describe('autoNumeric options and `options.*` methods', () => {
             document.body.removeChild(form);
         });
 
-        it('should not modify how non-AutoNumeric or input event bubble up', () => { //FIXME The `testingFunc()` is called, but somehow Jasmine spy does not pick that up
+        it('should not modify how non-AutoNumeric or input event bubble up', () => {
             const spy = spyOn(customFunction, 'testingFunc');
             aNInput = new AutoNumeric(input, { eventBubbles: AutoNumeric.options.eventBubbles.doesNotBubble });
             form.addEventListener('click', e => customFunction.testingFunc(e));

--- a/test/unit/autoNumeric.spec.js
+++ b/test/unit/autoNumeric.spec.js
@@ -1562,9 +1562,9 @@ describe('autoNumeric options and `options.*` methods', () => {
                 },
             };
 
-            // Setup the event listeners
-            form.addEventListener('click', customFunction.testingFunc);
-            input.addEventListener('click', customFunction.testingFunc);
+            // Event listeners should be added after customFunction.testingFunc has been 'decorated' by the spyOn API
+            // form.addEventListener('click', customFunction.testingFunc);
+            // input.addEventListener('click', customFunction.testingFunc);
         });
 
         afterEach(() => { // Un-initialization
@@ -1573,9 +1573,12 @@ describe('autoNumeric options and `options.*` methods', () => {
             document.body.removeChild(form);
         });
 
-        xit('should not modify how non-AutoNumeric or input event bubble up', () => { //FIXME The `testingFunc()` is called, but somehow Jasmine spy does not pick that up
+        it('should not modify how non-AutoNumeric or input event bubble up', () => { //FIXME The `testingFunc()` is called, but somehow Jasmine spy does not pick that up
             const spy = spyOn(customFunction, 'testingFunc');
             aNInput = new AutoNumeric(input, { eventBubbles: AutoNumeric.options.eventBubbles.doesNotBubble });
+            form.addEventListener('click', e => customFunction.testingFunc(e));
+            input.addEventListener('click', e => customFunction.testingFunc(e));
+
             aNInput.node().click();
             expect(customFunction.testingFunc).toHaveBeenCalledTimes(2);
 
@@ -4341,7 +4344,7 @@ describe('Modifying the options after initialization', () => {
     });
 });
 
-xdescribe('Managing external changes', () => { //XXX This test is deactivated since PhantomJS is failing when defining some properties with `Object.defineProperty`. See issue https://github.com/ariya/phantomjs/issues/13895
+describe('Managing external changes', () => {
     it(`should watch for external change to the input 'value' attribute`, () => {
         // Initialization
         const inputElement = document.createElement('input');
@@ -5294,7 +5297,16 @@ describe('Instantiated autoNumeric functions', () => {
             expect(aNInput.node().selectionStart).toEqual(0);
             expect(aNInput.node().selectionEnd).toEqual(6);
 
-            //TODO Test the decimalPlacesShownOnBlur with the selections
+            // Test the decimalPlacesShownOnBlur with the selections
+            aNInput.node().dispatchEvent(new window.Event('blur', { bubbles: false, cancelable: false }));
+            expect(aNInput.getFormatted()).toEqual('12.266,123\u202f€');
+            aNInput.selectDecimal();
+            expect(aNInput.node().selectionStart).toEqual(7);
+            expect(aNInput.node().selectionEnd).toEqual(10);
+
+            aNInput.selectInteger();
+            expect(aNInput.node().selectionStart).toEqual(0);
+            expect(aNInput.node().selectionEnd).toEqual(6);
 
             // Common configuration
             aNInput.update({ suffixText: 'suffixText', minimumValue: '-9999999', maximumValue: '9999999', decimalPlaces: 2 });


### PR DESCRIPTION
Added getGetterSetter to AutoNumericHelper.js and call it from the constructor for the 'watch external changes' functionality

After this fix, the test suite 'Managing external changes' could be reenabled and it works perfectly.

I've also fixed one spec related to event bubbling (minor fix was needed) and implemented a test case according to the TODO comment related to decimalPlacesShownOnBlur functionality.

Please let me know if I could help merging my PRs.