### PR TITLE
Fix a flaky test: 'should fail to init when the default value is outside of the min and max limits' 

### DIFF
--- a/test/unit/autoNumeric.spec.js
+++ b/test/unit/autoNumeric.spec.js
@@ -3293,7 +3293,8 @@ describe('Initialization calls', () => {
         });
 
         afterEach(() => { // Un-initialization
-            aNInput.remove();
+            aNInput?.remove();  // "?.": There is one where we test that AN cannot be created - if it is the first to run, ANInput is undefined and this throws an exception
+            aNInput = null;
             document.body.removeChild(newInput);
         });
 


### PR DESCRIPTION
This test fails if it is the first one to execute because it does not create an AutoNumeric instance and when afterEach runs, it throws an exception because aNInput in undefined. This can be reproduced using seed: '79716'