### PR TITLE
fix #819 and add an e2e test case covering it

### DIFF
--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -6626,6 +6626,10 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
                     this.set(this.savedCancellableValue);
                     // And we need to send an 'input' event when setting back the initial value in order to make other scripts aware of the value change...
                     this._triggerEvent(AutoNumeric.events.native.input, e.target);
+
+                    // lastVal should be updated to properly detect change (#819)
+                    this.lastVal = AutoNumericHelper.getElementValue(e.target);
+                    this.throwInput = true;
                 }
             }
 

--- a/test/e2e/specs/autoNumeric.e2e.spec.js
+++ b/test/e2e/specs/autoNumeric.e2e.spec.js
@@ -4383,6 +4383,48 @@ describe('Issue #808', () => {
         expect(await issue808InputDetector.getValue()).toEqual('6');
         expect(await input.getValue()).toEqual('1 234');
     });
+
+    it(`ESC: Re-entering the last input value on the second attempt after pressing Escape should trigger the oninput event`, async () => {
+        // This has been reported under #819
+
+        // reset
+        const input = await $(selectors.issue808);
+        const issue808InputDetector = await $(selectors.issue808InputDetector);
+        await resetInputDetector();
+        await setAutonumericValue('');
+
+        await input.click();
+        expect(await issue808InputDetector.getValue()).toEqual('0');
+        expect(await input.getValue()).toEqual('');
+
+        // Put some value to the clipboard - Position caret after the last digit in the input, selection is empty - ctrl-V - select the pasted part only, backspace --> extra character is not deleted
+        await browser.keys(['1']);
+        await browser.keys(['2']);
+        await browser.keys(['3']);
+        expect(await input.getValue()).toEqual('123');
+        expect(await issue808InputDetector.getValue()).toEqual('3');
+
+        // Focus next input
+        await browser.keys(Key.Tab);
+        expect(await input.isFocused()).toEqual(false);
+
+        // modify value and revert by the ESC key
+        await input.click();
+        await browser.keys([Key.Home]);
+        await browser.keys(['5']);
+        expect(await input.getValue()).toEqual('5 123');
+        expect(await issue808InputDetector.getValue()).toEqual('4');
+
+        await browser.keys([Key.Escape]);
+        expect(await input.getValue()).toEqual('123');
+        expect(await issue808InputDetector.getValue()).toEqual('5');
+
+        // Re-entering the last input value on the second attempt after pressing Escape should trigger the oninput event
+        await browser.keys([Key.Home]);
+        await browser.keys(['5']);
+        expect(await input.getValue()).toEqual('5 123');
+        expect(await issue808InputDetector.getValue()).toEqual('6');
+    });
 });
 
 describe('Issue #574', () => {


### PR DESCRIPTION
This PR fixes #819. The bug has been caused by lastVal not being updated internally when ESC keydown is handled. Actually, it is similar to #808.

I've also added an e2e test which tests that the input event is raised when the value is reentered. After the fix all unit and e2e tests succeed. As the root cause is similar to #808, I haven't created a separate 'describe' section for #819 in the e2e.spec.js, I've just extended the 'Issue #808' section with a new test case and reused its input controls/utility functions.