### PR TITLE
fix #670 (Copy pasting value adds incorrect additional comma/decimal to rawValue), add e2e tests related to this fix

### DIFF
--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -7436,6 +7436,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
                 // Do nothing
                 // Fall through
                 default :
+                    this.formatted = true; // This prevents the `keyup` event on the `v` key during a paste to try to format and set the value to 0
                     return; // ...and nothing else should be changed
             }
         }

--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -7369,6 +7369,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
 
         // 5. Check if the result is a valid number, if not, drop the paste and do nothing.
         if (!AutoNumericHelper.isNumber(result) || result === '') {
+            this.formatted = true; // This prevents the `keyup` event on the `v` key during a paste to try to format an empty value (compare with 3. above)
             if (this.settings.onInvalidPaste === AutoNumeric.options.onInvalidPaste.error) {
                 AutoNumericHelper.throwError(`The pasted value '${rawPastedText}' would result into an invalid content '${result}'.`); //TODO Should we send a warning instead of throwing an error?
                 //TODO This is not DRY ; refactor with above
@@ -7406,6 +7407,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
         let valueHasBeenClamped = false;
         try {
             this.set(result);
+            this.formatted = true; // This prevents the `keyup` event on the `v` key during a paste to try to reformat
             valueHasBeenSet = true;
         } catch (error) {
             let clampedValue;
@@ -7426,6 +7428,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
                 case AutoNumeric.options.onInvalidPaste.truncate:
                 case AutoNumeric.options.onInvalidPaste.replace:
                     // Throw an error message
+                    this.formatted = true; // This prevents the `keyup` event on the `v` key during a paste to try to format and set the value to 0
                     AutoNumericHelper.throwError(`The pasted value '${rawPastedText}' results in a value '${result}' that is outside of the minimum [${this.settings.minimumValue}] and maximum [${this.settings.maximumValue}] value range.`);
                 // Fall through
                 case AutoNumeric.options.onInvalidPaste.ignore:

--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -7414,6 +7414,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
             switch (this.settings.onInvalidPaste) {
                 case AutoNumeric.options.onInvalidPaste.clamp:
                     clampedValue = AutoNumericHelper.clampToRangeLimits(result, this.settings);
+                    this.formatted = true; // This prevents the `keyup` event on the `v` key during a paste to try to reformat
                     try {
                         this.set(clampedValue);
                     } catch (error) {

--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -6865,7 +6865,6 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
         this._updateInternalProperties(e);
 
         const skip = this._processNonPrintableKeysAndShortcuts(e);
-        delete this.valuePartsBeforePaste;
         const targetValue = AutoNumericHelper.getElementValue(e.target);
         if (skip || targetValue === '' && this.initialValueOnFirstKeydown === '') { // If the user enters skippable keys, or keeps deleting/backspacing into the empty input, no 'formatted' event are sent (cf. issue #621)
             return;
@@ -8894,30 +8893,6 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
     }
 
     /**
-     * Try to strip pasted value to digits
-     */
-    _checkPaste() {
-        // Do not process anything if the value has already been formatted
-        if (this.formatted) {
-            return;
-        }
-
-        if (!AutoNumericHelper.isUndefined(this.valuePartsBeforePaste)) {
-            const oldParts = this.valuePartsBeforePaste;
-            const [left, right] = this._getLeftAndRightPartAroundTheSelection();
-
-            // Try to strip the pasted value first
-            delete this.valuePartsBeforePaste;
-
-            const modifiedLeftPart = left.substr(0, oldParts[0].length) + AutoNumeric._stripAllNonNumberCharactersExceptCustomDecimalChar(left.substr(oldParts[0].length), this.settings, true, this.isFocused);
-            if (!this._setValueParts(modifiedLeftPart, right, true)) {
-                this._setElementValue(oldParts.join(''), false);
-                this._setCaretPosition(oldParts[0].length);
-            }
-        }
-    }
-
-    /**
      * Return `true` if the given key should be ignored or not.
      *
      * @param {string} eventKeyName
@@ -8947,14 +8922,6 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
      * @private
      */
     _processNonPrintableKeysAndShortcuts(e) {
-        // Catch the ctrl up on ctrl-v
-        if (((e.ctrlKey || e.metaKey) && e.type === 'keyup' && !AutoNumericHelper.isUndefined(this.valuePartsBeforePaste)) || (e.shiftKey && this.eventKey === AutoNumericEnum.keyName.Insert)) {
-            //TODO Move this test inside the `onKeyup` handler
-            this._checkPaste();
-
-            return false;
-        }
-
         // Skip all function keys (F1-F12), Windows keys, tab and other special keys
         if (this.constructor._shouldSkipEventKey(this.eventKey)) {
             return true;
@@ -8979,17 +8946,6 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
              this.eventKey === AutoNumericEnum.keyName.x)) {
             if (e.type === 'keydown') {
                 this._expandSelectionOnSign();
-            }
-
-            // Try to prevent wrong paste
-            if (this.eventKey === AutoNumericEnum.keyName.v || this.eventKey === AutoNumericEnum.keyName.Insert) {
-                if (e.type === 'keydown' || e.type === 'keypress') {
-                    if (AutoNumericHelper.isUndefined(this.valuePartsBeforePaste)) {
-                        this.valuePartsBeforePaste = this._getLeftAndRightPartAroundTheSelection();
-                    }
-                } else {
-                    this._checkPaste();
-                }
             }
 
             return e.type === 'keydown' || e.type === 'keypress' || this.eventKey === AutoNumericEnum.keyName.c;

--- a/src/AutoNumericHelper.js
+++ b/src/AutoNumericHelper.js
@@ -442,7 +442,7 @@ export default class AutoNumericHelper {
 
     /**
      * Return an object containing the name and version of the current browser.
-     * @example `browserVersion()` => { name: 'Firefox', version: '42' }
+     * @example `browser()` => { name: 'firefox', version: '42' }
      * Based on http://stackoverflow.com/a/38080051/2834898
      *
      * @returns {{ name: string, version: string }}
@@ -481,7 +481,7 @@ export default class AutoNumericHelper {
      */
     static isSeleniumBot() {
         // noinspection JSUnresolvedVariable
-        return window.navigator.webdriver === true;
+        return window.navigator.webdriver === true && this.browser().name === 'firefox';  // Should return false if executed under chromium/webdriver (both the geckodriver and the webdriver set window.navigator.webdriver to true)
     }
 
     /**

--- a/test/e2e/index.html
+++ b/test/e2e/index.html
@@ -1255,7 +1255,6 @@
 			</div>
 		</div>
 	</div>
-</div>
 
 	<div class="testSuite">
 		<div class="test">
@@ -1264,7 +1263,9 @@
 				<input id="issue_582" type="text" placeholder="#582" value="1234.5678">
 			</div>
 		</div>
-	</div></div>
+	</div>
+
+</div>
 
 <script>
     console.log(`-------------------------------------------`);
@@ -2646,6 +2647,7 @@
         decimalCharacter: ',',
         digitGroupSeparator: '.',
         minimumValue: '-10'
+    });
     
     //-------------- Issue #582
     new AutoNumeric('#issue_582', {

--- a/test/e2e/index.html
+++ b/test/e2e/index.html
@@ -1246,6 +1246,15 @@
 			</div>
 		</div>
 	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #670</p>
+			<div>
+				<input id="issue_670" type="text" placeholder="#670" value="1000">
+			</div>
+		</div>
+	</div>
 </div>
 
 <script>
@@ -2607,7 +2616,6 @@
 
     new AutoNumeric('#issue_799', null, anOptions799);
 
-
     //-------------- Issue #808
     new AutoNumeric('#issue_808', {
         "decimalPlaces": 0,
@@ -2623,6 +2631,13 @@
         issue808InputDetector.value = ++issue808InputCount;
     });
 
+    //-------------- Issue #670
+    new AutoNumeric('#issue_670', {
+        currencySymbol: '$',
+        decimalCharacter: ',',
+        digitGroupSeparator: '.',
+        minimumValue: '-10'
+    });
 </script>
 </body>
 </html>

--- a/test/e2e/specs/autoNumeric.e2e.spec.js
+++ b/test/e2e/specs/autoNumeric.e2e.spec.js
@@ -302,6 +302,20 @@ const getCaretStart = async domId => {
 };
 
 /**
+ * Returns the result of getNumericString method (rawValue as string)
+ * @param {string} domId  The input id that already managed by an AutoNumeric instance
+ * @returns {Promise<string>} 
+ */
+// eslint-disable-next-line arrow-body-style
+const getNumericString = async domId => {
+    return await browser.execute(domId => {
+        const input = document.querySelector(domId);
+        const an = AutoNumeric.getAutoNumericElement(input);
+        return an.getNumericString();
+    }, domId);
+};
+
+/**
  * Sends Ctrl-char key combination (e.g.: Ctrl-x or Ctrl-z) to the currently focused element (input)
  * @param {string} char  character to send as part of the ctrl-char sequence
  * @returns {Promise<void>} 
@@ -3964,7 +3978,7 @@ describe('Pasting', () => {
         expect(await issue387inputCancellable.getValue()).toEqual('$220,242.76');
     });
 
-    it('should not be possible to paste an valid number in a readOnly element', async () => {
+    it('should not be possible to paste a valid number in a readOnly element', async () => {
         const readOnlyElement = await $(selectors.readOnlyElement);
         expect(await readOnlyElement.getValue()).toEqual('42.42');
 
@@ -3983,6 +3997,77 @@ describe('Pasting', () => {
         await browser.keys([Key.Home, Key.ArrowRight, Key.Shift, Key.ArrowRight, Key.ArrowRight, Key.Shift]);
         await browser.keys([Key.Control, 'a', 'v', Key.Control]);
         expect(await readOnlyElement.getValue()).toEqual('42.42'); // No changes!
+    });
+
+    it('should not corrupt rawValue on pasting values (issue #670)', async () => {
+        // Reusing input from #387. We will modify the instance's configuration and consequently it introduces order dependency. If specs are execute randomly it may cause problems, but there are already some specs with order dependency.
+        const inputClassic = await $(selectors.inputClassic);
+        const inputToTest = await $(selectors.issue387inputCancellableNumOnly);
+
+        // 1. Test #670
+
+        // Prepare clipboard
+        await inputClassic.click();
+        await sendCtrlChar('a');
+        await browser.keys([Key.Backspace]);
+        await browser.keys('123456');
+        expect(await inputClassic.getValue()).toEqual('123456');
+        await sendCtrlChar('a');
+        await sendCtrlChar('c');
+
+        // Update options
+        await browser.execute(domId => {
+            const input = document.querySelector(domId);
+            const an = AutoNumeric.getAutoNumericElement(input);
+            an.update({
+                decimalCharacter: ',',
+                digitGroupSeparator: '.',
+                minimumValue: '-10',
+                selectNumbersOnly: true,
+            });
+        }, selectors.issue387inputCancellableNumOnly);
+
+        // Set starting value
+        await inputToTest.click();
+        await sendCtrlChar('a');
+        await browser.keys([Key.Backspace]);
+        await browser.keys('100000');
+        await inputClassic.click();
+        expect(await inputToTest.getValue()).toEqual('$100.000,00');
+        expect(await getNumericString(selectors.issue387inputCancellableNumOnly)).toEqual('100000');
+
+        // Paste
+        await inputToTest.click();
+        await sendCtrlChar('a');
+        expect(await getCaretStart(selectors.issue387inputCancellableNumOnly)).toEqual(1);  // The currency sign should not be selected, so that the branch of partial selection is executed in _onPaste
+
+        await browser.execute(() => {
+            window.e2eLogs = '';
+        });
+        await sendCtrlChar('v');
+
+        expect(await inputToTest.getValue()).toEqual('$123.456,00');  // Must be properly formatted
+        expect(await getNumericString(selectors.issue387inputCancellableNumOnly)).toEqual('123456');  // rawValue (or more precisely getNumericString()=the rawValue converted to string and extraneous zeros removed after the dot) convert) must be correct (e.g.: not "123456.00,")
+
+        // 2. Test if the pasted value is outside of the range (and throws an exception and rawValue should not be changed)
+
+        // Prepare clipboard
+        await inputClassic.click();
+        await sendCtrlChar('a');
+        await browser.keys([Key.Backspace]);
+        await browser.keys('-100');
+        expect(await inputClassic.getValue()).toEqual('-100');
+        await sendCtrlChar('a');
+        await sendCtrlChar('c');
+
+        // Paste
+        await inputToTest.click();
+        await sendCtrlChar('a');
+        expect(await getCaretStart(selectors.issue387inputCancellableNumOnly)).toEqual(1);  // The currency sign should not be selected, so that the branch of partial selection is executed in _onPaste
+        await sendCtrlChar('v');
+
+        expect(await inputToTest.getValue()).toEqual('$123.456,00');  // Value must be properly formatted and not changed
+        expect(await getNumericString(selectors.issue387inputCancellableNumOnly)).toEqual('123456');  // rawValue should be consistent with the displayed value
     });
 });
 

--- a/test/e2e/specs/autoNumeric.e2e.spec.js
+++ b/test/e2e/specs/autoNumeric.e2e.spec.js
@@ -4028,10 +4028,6 @@ describe('Pasting', () => {
         await inputToTest.click();
         await sendCtrlChar('a');
         expect(await getCaretStart(selectors.issue670)).toEqual(1);  // The currency sign should not be selected, so that the branch of partial selection is executed in _onPaste
-
-        await browser.execute(() => {
-            window.e2eLogs = '';
-        });
         await sendCtrlChar('v');
 
         expect(await inputToTest.getValue()).toEqual('$123.456,00');  // Must be properly formatted

--- a/test/e2e/specs/autoNumeric.e2e.spec.js
+++ b/test/e2e/specs/autoNumeric.e2e.spec.js
@@ -4033,7 +4033,7 @@ describe('Pasting', () => {
         expect(await inputToTest.getValue()).toEqual('$123.456,00');  // Must be properly formatted
         expect(await getNumericString(selectors.issue670)).toEqual('123456');  // rawValue (or more precisely getNumericString()=the rawValue converted to string and extraneous zeros removed after the dot) must be correct (e.g.: not "123456.00,")
 
-        // 2. Test if the pasted value is outside of the range (and throws an exception and rawValue should not be changed)
+        // 2. Test when the pasted value is outside of the range (and it throws an exception and rawValue should not be changed)
 
         // Prepare clipboard
         await inputClassic.click();
@@ -4053,7 +4053,7 @@ describe('Pasting', () => {
         expect(await inputToTest.getValue()).toEqual('$123.456,00');  // Value must be properly formatted and not changed
         expect(await getNumericString(selectors.issue670)).toEqual('123456');  // rawValue should be consistent with the displayed value
 
-        // 3. Test when onInvalidPaste=clamp and the pasted value is outside of the range (and updates the value based on the min=max limits and rawValue should get corrupted)
+        // 3. Test when onInvalidPaste=clamp and the pasted value is outside of the range (and updates the value based on the min/max limits)
 
         // Update options
         await browser.execute(domId => {
@@ -4072,6 +4072,35 @@ describe('Pasting', () => {
 
         expect(await inputToTest.getValue()).toEqual('-$10,00');  // Value must be clamped and properly formatted
         expect(await getNumericString(selectors.issue670)).toEqual('-10');  // rawValue should be consistent with the displayed value
+
+        // 4. Test when onInvalidPaste=ignore and the pasted value is outside of the range (and value should not be changed)
+
+        // Update options
+        await browser.execute(domId => {
+            const input = document.querySelector(domId);
+            const an = AutoNumeric.getAutoNumericElement(input);
+            an.update({
+                onInvalidPaste: 'ignore',
+            });
+        }, selectors.issue670);
+
+        // Prepare input
+        await inputToTest.click();
+        await sendCtrlChar('a');
+        await browser.keys([Key.Backspace, Key.Backspace]);
+        await browser.keys('123456');
+        await browser.keys([Key.Tab]);  // Format it
+        expect(await inputToTest.getValue()).toEqual('$123.456,00');  // Value must be properly formatted
+        expect(await getNumericString(selectors.issue670)).toEqual('123456');  // rawValue should be consistent with the displayed value
+
+        // Paste
+        await inputToTest.click();
+        await sendCtrlChar('a');
+        expect(await getCaretStart(selectors.issue670)).toEqual(1);  // The currency sign should not be selected, so that the branch of partial selection is executed in _onPaste
+        await sendCtrlChar('v');
+
+        expect(await inputToTest.getValue()).toEqual('$123.456,00');  // Value must not be changed
+        expect(await getNumericString(selectors.issue670)).toEqual('123456');  // rawValue should be consistent with the displayed value
     });
 });
 

--- a/test/e2e/specs/autoNumeric.e2e.spec.js
+++ b/test/e2e/specs/autoNumeric.e2e.spec.js
@@ -273,6 +273,7 @@ const selectors = {
     issue768Submit                    : '#issue_768_submit',
     issue808                          : '#issue_808',
     issue808InputDetector             : '#issue_808_input_detector',
+    issue670                          : '#issue_670',
 };
 
 //-----------------------------------------------------------------------------
@@ -4000,9 +4001,8 @@ describe('Pasting', () => {
     });
 
     it('should not corrupt rawValue on pasting values (issue #670)', async () => {
-        // Reusing input from #387. We will modify the instance's configuration and consequently it introduces order dependency. If specs are execute randomly it may cause problems, but there are already some specs with order dependency.
         const inputClassic = await $(selectors.inputClassic);
-        const inputToTest = await $(selectors.issue387inputCancellableNumOnly);
+        const inputToTest = await $(selectors.issue670);
 
         // 1. Test #670
 
@@ -4015,18 +4015,6 @@ describe('Pasting', () => {
         await sendCtrlChar('a');
         await sendCtrlChar('c');
 
-        // Update options
-        await browser.execute(domId => {
-            const input = document.querySelector(domId);
-            const an = AutoNumeric.getAutoNumericElement(input);
-            an.update({
-                decimalCharacter: ',',
-                digitGroupSeparator: '.',
-                minimumValue: '-10',
-                selectNumbersOnly: true,
-            });
-        }, selectors.issue387inputCancellableNumOnly);
-
         // Set starting value
         await inputToTest.click();
         await sendCtrlChar('a');
@@ -4034,12 +4022,12 @@ describe('Pasting', () => {
         await browser.keys('100000');
         await inputClassic.click();
         expect(await inputToTest.getValue()).toEqual('$100.000,00');
-        expect(await getNumericString(selectors.issue387inputCancellableNumOnly)).toEqual('100000');
+        expect(await getNumericString(selectors.issue670)).toEqual('100000');
 
         // Paste
         await inputToTest.click();
         await sendCtrlChar('a');
-        expect(await getCaretStart(selectors.issue387inputCancellableNumOnly)).toEqual(1);  // The currency sign should not be selected, so that the branch of partial selection is executed in _onPaste
+        expect(await getCaretStart(selectors.issue670)).toEqual(1);  // The currency sign should not be selected, so that the branch of partial selection is executed in _onPaste
 
         await browser.execute(() => {
             window.e2eLogs = '';
@@ -4047,7 +4035,7 @@ describe('Pasting', () => {
         await sendCtrlChar('v');
 
         expect(await inputToTest.getValue()).toEqual('$123.456,00');  // Must be properly formatted
-        expect(await getNumericString(selectors.issue387inputCancellableNumOnly)).toEqual('123456');  // rawValue (or more precisely getNumericString()=the rawValue converted to string and extraneous zeros removed after the dot) convert) must be correct (e.g.: not "123456.00,")
+        expect(await getNumericString(selectors.issue670)).toEqual('123456');  // rawValue (or more precisely getNumericString()=the rawValue converted to string and extraneous zeros removed after the dot) must be correct (e.g.: not "123456.00,")
 
         // 2. Test if the pasted value is outside of the range (and throws an exception and rawValue should not be changed)
 
@@ -4063,11 +4051,31 @@ describe('Pasting', () => {
         // Paste
         await inputToTest.click();
         await sendCtrlChar('a');
-        expect(await getCaretStart(selectors.issue387inputCancellableNumOnly)).toEqual(1);  // The currency sign should not be selected, so that the branch of partial selection is executed in _onPaste
+        expect(await getCaretStart(selectors.issue670)).toEqual(1);  // The currency sign should not be selected, so that the branch of partial selection is executed in _onPaste
         await sendCtrlChar('v');
 
         expect(await inputToTest.getValue()).toEqual('$123.456,00');  // Value must be properly formatted and not changed
-        expect(await getNumericString(selectors.issue387inputCancellableNumOnly)).toEqual('123456');  // rawValue should be consistent with the displayed value
+        expect(await getNumericString(selectors.issue670)).toEqual('123456');  // rawValue should be consistent with the displayed value
+
+        // 3. Test when onInvalidPaste=clamp and the pasted value is outside of the range (and updates the value based on the min=max limits and rawValue should get corrupted)
+
+        // Update options
+        await browser.execute(domId => {
+            const input = document.querySelector(domId);
+            const an = AutoNumeric.getAutoNumericElement(input);
+            an.update({
+                onInvalidPaste: 'clamp',
+            });
+        }, selectors.issue670);
+
+        // Paste
+        await inputToTest.click();
+        await sendCtrlChar('a');
+        expect(await getCaretStart(selectors.issue670)).toEqual(1);  // The currency sign should not be selected, so that the branch of partial selection is executed in _onPaste
+        await sendCtrlChar('v');
+
+        expect(await inputToTest.getValue()).toEqual('-$10,00');  // Value must be clamped and properly formatted
+        expect(await getNumericString(selectors.issue670)).toEqual('-10');  // rawValue should be consistent with the displayed value
     });
 });
 

--- a/test/e2e/specs/autoNumeric.e2e.spec.js
+++ b/test/e2e/specs/autoNumeric.e2e.spec.js
@@ -4033,7 +4033,36 @@ describe('Pasting', () => {
         expect(await inputToTest.getValue()).toEqual('$123.456,00');  // Must be properly formatted
         expect(await getNumericString(selectors.issue670)).toEqual('123456');  // rawValue (or more precisely getNumericString()=the rawValue converted to string and extraneous zeros removed after the dot) must be correct (e.g.: not "123456.00,")
 
+        // 1a Pasting digits+non-digit characters (123millimeter)
+
+        // Prepare clipboard
+        await inputClassic.click();
+        await sendCtrlChar('a');
+        await browser.keys([Key.Backspace]);
+        await browser.keys('123millimeter');
+        expect(await inputClassic.getValue()).toEqual('123millimeter');
+        await sendCtrlChar('a');
+        await sendCtrlChar('c');
+
+        // Paste
+        await inputToTest.click();
+        await sendCtrlChar('a');
+        expect(await getCaretStart(selectors.issue670)).toEqual(1);  // The currency sign should not be selected, so that the branch of partial selection is executed in _onPaste
+        await sendCtrlChar('v');
+
+        expect(await inputToTest.getValue()).toEqual('$123,00');  // Value must be properly formatted and changed
+        expect(await getNumericString(selectors.issue670)).toEqual('123');  // rawValue should be consistent with the displayed value
+
         // 2. Test when the pasted value is outside of the range (and it throws an exception and rawValue should not be changed)
+
+        // Prepare input
+        await inputToTest.click();
+        await sendCtrlChar('a');
+        await browser.keys([Key.Backspace, Key.Backspace]);
+        await browser.keys('123456');
+        await browser.keys([Key.Tab]);  // Format it
+        expect(await inputToTest.getValue()).toEqual('$123.456,00');  // Value must be properly formatted
+        expect(await getNumericString(selectors.issue670)).toEqual('123456');  // rawValue should be consistent with the displayed value
 
         // Prepare clipboard
         await inputClassic.click();


### PR DESCRIPTION
See #670 for further details 