### PR TITLE
Improve js doc comments + other minor fixes

### DIFF
--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -1475,7 +1475,7 @@ export default class AutoNumeric {
     /**
      * Return the 'submit' event handler function used for the parent form.
      *
-     * @returns {function}
+     * @returns {Function}
      * @private
      */
     _getFormHandlerFunction() {

--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -133,6 +133,8 @@ export default class AutoNumeric {
         this.savedCancellableValue = null;
 
         // Initialize the undo/redo variables
+        /** @typedef {{ value: string|null|number, start: number, end: string }} HistoryTableEntry */  // TODO can rawValue be number?
+        /** @type {Array<HistoryTableEntry>} */
         this.historyTable = []; // Keep track of *all* valid states of the element value
         this.historyTableIndex = -1; // Pointer to the current undo/redo state. This will be set to '0' during initialization since it first adds itself.
         this.onGoingRedo = false; // Variable that keeps track if a 'redo' is ongoing (in order to prevent an 'undo' to be launch when releasing the shift key before the ctrl key after a 'redo' shortcut)
@@ -1354,7 +1356,7 @@ export default class AutoNumeric {
     /**
      * Set the count of AutoNumeric form children to 1 for the given form element, or if none are passed, the current `this.parentForm` one.
      *
-     * @param {HTMLFormElement|null} formElement
+     * @param {HTMLFormElement|null} [formElement=null]
      * @private
      */
     _initializeFormCounterToOne(formElement = null) {
@@ -1415,8 +1417,8 @@ export default class AutoNumeric {
     /**
      * Return the given form element, or defaults to `this.parentForm` if no argument is passed.
      *
-     * @param {HTMLFormElement|null} formElement
-     * @returns {*}
+     * @param {HTMLFormElement|null} [formElement=null]
+     * @returns {HTMLFormElement}
      * @private
      */
     _getFormElement(formElement = null) {
@@ -1434,7 +1436,7 @@ export default class AutoNumeric {
      * Generate a form handler unique name and store it in the global form handler list.
      * This also save that name in the dataset of the given form element.
      *
-     * @param {HTMLFormElement|null} formElement
+     * @param {HTMLFormElement|null} [formElement=null]
      * @private
      */
     _storeFormHandlerFunction(formElement = null) {
@@ -1454,7 +1456,7 @@ export default class AutoNumeric {
     /**
      * Return the form handler key name from the parent form element, for the global form handler list.
      *
-     * @returns {string|*}
+     * @returns {string}
      * @private
      */
     _getFormHandlerKey() {
@@ -1501,7 +1503,7 @@ export default class AutoNumeric {
      * Set the DOM element write permissions according to the current settings, by setting the `readonly` or `contenteditable` attributes depending on its tag type.
      * If the `useHtmlAttribute` parameter is set to `true`, then the `readonly` html attribute is used and has precedence over the `readOnly` option to set the element as read-only.
      *
-     * @param {boolean} useHtmlAttribute If set to `true`, then the write permissions are set by taking into account the html 'readonly' attribute, even if the `readOnly` option is set to false
+     * @param {boolean} [useHtmlAttribute=false] If set to `true`, then the write permissions are set by taking into account the html 'readonly' attribute, even if the `readOnly` option is set to false
      * @private
      */
     _setWritePermissions(useHtmlAttribute = false) {
@@ -1721,7 +1723,7 @@ export default class AutoNumeric {
      * 'Undo' or 'Redo' the last/next user entry in the history table.
      * This does not modify the history table, only the pointer to the current state.
      *
-     * @param {boolean} undo If set to `true`, then this function does an 'Undo', otherwise it does a 'Redo'
+     * @param {boolean} [undo=true] If set to `true`, then this function does an 'Undo', otherwise it does a 'Redo' (Optional, default: true)
      * @private
      */
     _historyTableUndoOrRedo(undo = true) {
@@ -1792,8 +1794,8 @@ export default class AutoNumeric {
      * Make the history table forget its first N elements, shifting its indexes in the process.
      * `N` being given as the `numberOfEntriesToForget` parameter.
      *
-     * @param {Number} numberOfEntriesToForget
-     * @returns {object|Array<object>} The discarded objects, in an Array.
+     * @param {Number} [numberOfEntriesToForget=1] (Optional, default: 1)
+     * @returns {HistoryTableEntry|Array<HistoryTableEntry>} The discarded objects, in an Array.
      * @private
      */
     _historyTableForget(numberOfEntriesToForget = 1) {
@@ -2056,8 +2058,8 @@ export default class AutoNumeric {
      * @example anElement.set(null) // Set the rawValue and element value to `null`
      *
      * @param {number|string|null} newValue The value must be a Number, a numeric string or `null` (if `emptyInputBehavior` is set to `'null'`)
-     * @param {object} options A settings object that will override the current settings. Note: the update is done only if the `newValue` is defined.
-     * @param {boolean} saveChangeToHistory If set to `true`, then the change is recorded in the history table
+     * @param {object} [options=null] A settings object that will override the current settings. Note: the update is done only if the `newValue` is defined.
+     * @param {boolean} [saveChangeToHistory=true] If set to `true`, then the change is recorded in the history table
      * @returns {AutoNumeric}
      * @throws
      */
@@ -2196,7 +2198,7 @@ export default class AutoNumeric {
      * You can also set the value and update the setting in one go (the value will again not be formatted immediately).
      *
      * @param {number|string} value
-     * @param {object} options
+     * @param {object} [options=null]
      * @returns {AutoNumeric}
      * @throws
      */
@@ -2232,7 +2234,7 @@ export default class AutoNumeric {
      * This also updates the `rawValue` with the given `newValue`, without checking it too ; if it's not formatted like a number recognized by Javascript, this *will* likely make other AutoNumeric methods fail.
      *
      * @param {string|number|null} newValue The new value to set on the element
-     * @param {boolean} saveChangeToHistory If set to `true`, then the change is recorded in the history array, otherwise it is not
+     * @param {boolean} [saveChangeToHistory=true] If set to `true`, then the change is recorded in the history array, otherwise it is not
      * @returns {AutoNumeric}
      */
     setValue(newValue, saveChangeToHistory = true) {
@@ -2245,7 +2247,7 @@ export default class AutoNumeric {
      * Save the raw value inside the AutoNumeric object.
      *
      * @param {number|string|null} rawValue The numeric value as understood by Javascript like a `Number`
-     * @param {boolean} saveChangeToHistory If set to `true`, then the change is recorded in the history array, otherwise it is not
+     * @param {boolean} [saveChangeToHistory=true] If set to `true`, then the change is recorded in the history array, otherwise it is not
      * @private
      */
     _setRawValue(rawValue, saveChangeToHistory = true) {
@@ -2285,7 +2287,7 @@ export default class AutoNumeric {
      * This sends an 'autoNumeric:formatted' event if the new value is different from the old one.
      *
      * @param {number|string} newElementValue
-     * @param {boolean} sendFormattedEvent If set to `true`, then the `AutoNumeric.events.formatted` event is sent if the value has changed
+     * @param {boolean} [sendFormattedEvent=true] If set to `true`, then the `AutoNumeric.events.formatted` event is sent if the value has changed
      * @returns {AutoNumeric}
      * @private
      */
@@ -2322,8 +2324,8 @@ export default class AutoNumeric {
      * Note: if the second argument `rawValue` is a boolean, we consider that is really is the `saveChangeToHistory` argument.
      *
      * @param {number|string|null} newElementValue
-     * @param {number|string|null|boolean} rawValue
-     * @param {boolean} saveChangeToHistory
+     * @param {number|string|null|boolean} [rawValue=null]
+     * @param {boolean} [saveChangeToHistory=true]
      * @returns {AutoNumeric}
      * @private
      */
@@ -2441,7 +2443,7 @@ export default class AutoNumeric {
      *
      * @param {string} eventName
      * @param {HTMLElement|HTMLDocument|EventTarget} element
-     * @param {object} detail
+     * @param {object} [detail=null]
      * @private
      */
     _triggerEvent(eventName, element = document, detail = null) {
@@ -2473,7 +2475,7 @@ export default class AutoNumeric {
      *
      * @usage anElement.getNumericString();
      *
-     * @param {function|null} callback If a callback is passed, then the result is passed to it as its first argument, and the AutoNumeric object has its second
+     * @param {function|null} callback If a callback is passed, then the result is passed to it as its first argument, and the AutoNumeric object as its second
      *
      * @returns {string|null}
      */
@@ -2497,7 +2499,7 @@ export default class AutoNumeric {
      *
      * @usage anElement.getFormatted()
      *
-     * @param {function|null} callback If a callback is passed, then the result is passed to it as its first argument, and the AutoNumeric object has its second
+     * @param {function|null} callback If a callback is passed, then the result is passed to it as its first argument, and the AutoNumeric object as its second
      *
      * @returns {string}
      */
@@ -2519,7 +2521,7 @@ export default class AutoNumeric {
      *
      * @usage anElement.getNumber()
      *
-     * @param {function|null} callback If a callback is passed, then the result is passed to it as its first argument, and the AutoNumeric object has its second
+     * @param {function|null} callback If a callback is passed, then the result is passed to it as its first argument, and the AutoNumeric object as its second
      *
      * @returns {number|null}
      */
@@ -8411,11 +8413,11 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
 
     /**
      * Analyse the settings/options passed by the user, validate and clean them, then set them into `this.settings`.
-     * Note: This sets the settings to `null` if somehow the settings objet is undefined or empty
+     * Note: This sets the settings to `null` if somehow the settings object is undefined or empty
      *       If only `decimalPlaces` is defined in the option, overwrite the other decimalPlaces* options, otherwise, use those options
      *
      * @param {object} options
-     * @param {boolean} update - If set to `true`, then the settings already exists and this function only updates them instead of recreating them from scratch
+     * @param {boolean} [update=false] - If set to `true`, then the settings already exists and this function only updates them instead of recreating them from scratch
      * @throws
      */
     _setSettings(options, update = false) {
@@ -8622,8 +8624,8 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
     /**
      * Set the text selection inside the input with the given start and end position.
      *
-     * @param {int} start
-     * @param {int} end
+     * @param {number} start
+     * @param {number} end
      * @private
      */
     _setSelection(start, end) {
@@ -8835,7 +8837,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
     /**
      * Helper function for `_expandSelectionOnSign()`.
      *
-     * @returns {Array} Array containing [signPosition, currencySymbolPosition] of a formatted value
+     * @returns {[number, number]} Array containing [signPosition, currencySymbolPosition] of a formatted value
      * @private
      */
     _getSignPosition() {
@@ -8904,7 +8906,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
             // Try to strip the pasted value first
             delete this.valuePartsBeforePaste;
 
-            const modifiedLeftPart = left.substr(0, oldParts[0].length) + AutoNumeric._stripAllNonNumberCharactersExceptCustomDecimalChar(left.substr(oldParts[0].length), this.settings, true, this.isFocused);
+            const modifiedLeftPart = left.substring(0, oldParts[0].length) + AutoNumeric._stripAllNonNumberCharactersExceptCustomDecimalChar(left.substring(oldParts[0].length), this.settings, true, this.isFocused);
             if (!this._setValueParts(modifiedLeftPart, right, true)) {
                 this._setElementValue(oldParts.join(''), false);
                 this._setCaretPosition(oldParts[0].length);
@@ -9186,7 +9188,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
 
                 // Remove the decimal character if found on the far left of the right part
                 if (right.indexOf(this.settings.decimalCharacter) === 0) {
-                    right = right.substr(1);
+                    right = right.substring(1);
                 }
             }
 
@@ -9401,10 +9403,10 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
      * This is loosely based upon http://stackoverflow.com/a/40705993/2834898.
      *
      * @param {HTMLFormElement} form
-     * @param {boolean} intoAnArray If `true`, instead of generating a string, it generates an Array.
-     * @param {string} formatType If `'unformatted'`, then the AutoNumeric elements values are unformatted, if `'localized'`, then the AutoNumeric elements values are localized, and if `'formatted'`, then the AutoNumeric elements values are kept formatted. In either way, this function does not modify the value of each DOM element, but only affect the value that is returned by that serialize function.
-     * @param {string} serializedSpaceCharacter Can either be the '+' character, or the '%20' string.
-     * @param {string|null} forcedOutputFormat If set, then this is the format that is used for the localization, instead of the default `outputFormat` option.
+     * @param {boolean} [intoAnArray=false] If `true`, instead of generating a string, it generates an Array.
+     * @param {string} [formatType='unformatted'] If `'unformatted'`, then the AutoNumeric elements values are unformatted, if `'localized'`, then the AutoNumeric elements values are localized, and if `'formatted'`, then the AutoNumeric elements values are kept formatted. In either way, this function does not modify the value of each DOM element, but only affect the value that is returned by that serialize function.
+     * @param {string} [serializedSpaceCharacter='+'] Can either be the '+' character, or the '%20' string.
+     * @param {string|null} [forcedOutputFormat] If set, then this is the format that is used for the localization, instead of the default `outputFormat` option.
      * @returns {string|Array}
      * @private
      */
@@ -9496,7 +9498,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
      * Serialize the form values to a string, outputting numeric strings for each AutoNumeric-managed element values.
      *
      * @param {HTMLFormElement} form
-     * @param {string} serializedSpaceCharacter
+     * @param {string} [serializedSpaceCharacter='+']
      * @returns {string}
      */
     static _serializeNumericString(form, serializedSpaceCharacter = '+') {
@@ -9507,7 +9509,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
      * Serialize the form values to a string, outputting the formatted value as strings for each AutoNumeric-managed elements.
      *
      * @param {HTMLFormElement} form
-     * @param {string} serializedSpaceCharacter
+     * @param {string} [serializedSpaceCharacter='+']
      * @returns {string}
      */
     static _serializeFormatted(form, serializedSpaceCharacter = '+') {
@@ -9518,8 +9520,8 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
      * Serialize the form values to a string, outputting localized strings for each AutoNumeric-managed element values.
      *
      * @param {HTMLFormElement} form
-     * @param {string} serializedSpaceCharacter
-     * @param {string|null} forcedOutputFormat If set, then this is the format that is used for the localization, instead of the default `outputFormat` option.
+     * @param {string} [serializedSpaceCharacter='+']
+     * @param {string|null} [forcedOutputFormat] If set, then this is the format that is used for the localization, instead of the default `outputFormat` option.
      * @returns {string}
      */
     static _serializeLocalized(form, serializedSpaceCharacter = '+', forcedOutputFormat = null) {
@@ -9530,7 +9532,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
      * Generate an Array with the form values, outputting numeric strings for each AutoNumeric-managed element values.
      *
      * @param {HTMLFormElement} form
-     * @param {string} serializedSpaceCharacter
+     * @param {string} [serializedSpaceCharacter='+']
      * @returns {Array}
      */
     static _serializeNumericStringArray(form, serializedSpaceCharacter = '+') {
@@ -9541,7 +9543,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
      * Generate an Array with the form values, outputting the formatted value as strings for each AutoNumeric-managed elements.
      *
      * @param {HTMLFormElement} form
-     * @param {string} serializedSpaceCharacter
+     * @param {string} [serializedSpaceCharacter='+']
      * @returns {Array}
      */
     static _serializeFormattedArray(form, serializedSpaceCharacter = '+') {
@@ -9552,8 +9554,8 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
      * Generate an Array with the form values, outputting localized strings for each AutoNumeric-managed element values.
      *
      * @param {HTMLFormElement} form
-     * @param {string} serializedSpaceCharacter
-     * @param {string|null} forcedOutputFormat If set, then this is the format that is used for the localization, instead of the default `outputFormat` option.
+     * @param {string} [serializedSpaceCharacter='+']
+     * @param {string|null} [forcedOutputFormat] If set, then this is the format that is used for the localization, instead of the default `outputFormat` option.
      * @returns {Array}
      */
     static _serializeLocalizedArray(form, serializedSpaceCharacter = '+', forcedOutputFormat = null) {
@@ -9583,8 +9585,8 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
  * [anElement1, anElement2] = AutoNumeric.multiple('.myCssClass > input', [null, 12345.789], { options }); // Idem above, but with passing the initial values too
  *
  * @param {string|Array|{ rootElement: HTMLElement }|{ rootElement: HTMLElement, exclude: Array<HTMLInputElement>}} arg1
- * @param {number|Array|object|null} initialValue
- * @param {object|Array|null} options
+ * @param {number|Array|object|null} [initialValue]
+ * @param {object|Array|null} [options]
  * @returns {Array}
  */
 AutoNumeric.multiple = (arg1, initialValue = null, options = null) => {

--- a/src/AutoNumericHelper.js
+++ b/src/AutoNumericHelper.js
@@ -222,7 +222,7 @@ export default class AutoNumericHelper {
      * @returns {boolean}
      */
     static isInArray(needle, array) {
-        if (!this.isArray(array) || array === [] || this.isUndefined(needle)) {
+        if (!this.isArray(array) || this.isUndefined(needle)) {
             return false;
         }
 
@@ -492,8 +492,8 @@ export default class AutoNumericHelper {
      * Note: `-0` is not a negative number since it's equal to `0`.
      *
      * @param {number|string} numberOrNumericString A Number, or a number represented by a string
-     * @param {string} negativeSignCharacter The single character that represent the negative sign
-     * @param {boolean} checkEverywhere If TRUE, then the negative sign is search everywhere in the numeric string (this is needed for instance if the string is '1234.56-')
+     * @param {string} [negativeSignCharacter='-'] The single character that represent the negative sign
+     * @param {boolean} [checkEverywhere=true] If TRUE, then the negative sign is search everywhere in the numeric string (this is needed for instance if the string is '1234.56-')
      * @returns {boolean}
      */
     static isNegative(numberOrNumericString, negativeSignCharacter = '-', checkEverywhere = true) {
@@ -525,7 +525,7 @@ export default class AutoNumericHelper {
      * @example isNegativeStrict('-1,234.56 €') => true
      *
      * @param {string} numericString
-     * @param {string} negativeSignCharacter The single character that represent the negative sign
+     * @param {string} [negativeSignCharacter='-'] The single character that represent the negative sign
      * @returns {boolean}
      */
     static isNegativeStrict(numericString, negativeSignCharacter = '-') {
@@ -579,7 +579,7 @@ export default class AutoNumericHelper {
      * @returns {string}
      */
     static replaceCharAt(string, index, newCharacter) {
-        return `${string.substr(0, index)}${newCharacter}${string.substr(index + newCharacter.length)}`;
+        return `${string.substring(0, index)}${newCharacter}${string.substring(index + newCharacter.length)}`;
     }
 
     /**
@@ -687,7 +687,7 @@ export default class AutoNumericHelper {
      * Note: this also works with edge cases like contenteditable-enabled elements, and hidden inputs.
      *
      * @param {HTMLInputElement|EventTarget} element
-     * @returns {{}}
+     * @returns {{start: number, end: number, length: number}}
      */
     static getElementSelection(element) {
         const position = {};
@@ -727,8 +727,8 @@ export default class AutoNumericHelper {
      * Cross browser routine for setting selected range/cursor position
      *
      * @param {HTMLInputElement|EventTarget} element
-     * @param {int} start
-     * @param {int|null} end
+     * @param {number} start
+     * @param {number|null} [end=null]
      */
     static setElementSelection(element, start, end = null) {
         if (this.isUndefinedOrNullOrEmpty(end)) {
@@ -761,7 +761,7 @@ export default class AutoNumericHelper {
      * Function that display a warning messages, according to the debug level.
      *
      * @param {string} message
-     * @param {boolean} showWarning If FALSE, then the warning message is not displayed
+     * @param {boolean} [showWarning=true] If FALSE, then the warning message is not displayed
      */
     static warning(message, showWarning = true) {
         if (showWarning) {
@@ -840,7 +840,7 @@ export default class AutoNumericHelper {
             return value;
         }
 
-        return `${integerPart}.${decimalPart.substr(0, decimalPlaces)}`;
+        return `${integerPart}.${decimalPart.substring(0, decimalPlaces)}`;
     }
 
     /**
@@ -848,8 +848,8 @@ export default class AutoNumericHelper {
      * @example roundToNearest(264789, 10000)) => 260000
      *
      * @param {number} value
-     * @param {number} stepPlace
-     * @returns {*}
+     * @param {number} [stepPlace=1000] Rounding step size (optional, default: 1000)
+     * @returns {number}
      */
     static roundToNearest(value, stepPlace = 1000) {
         if (0 === value) {
@@ -904,7 +904,7 @@ export default class AutoNumericHelper {
      * @param {number} value
      * @param {boolean} isAddition
      * @param {int} decimalPlacesRawValue The precision needed by the `rawValue`
-     * @returns {*}
+     * @returns {number}
      */
     static modifyAndRoundToNearestAuto(value, isAddition, decimalPlacesRawValue) {
         value = Number(this.forceDecimalPlaces(value, decimalPlacesRawValue)); // Make sure that '0.13000000001' is converted to the number of rawValue decimal places '0.13'
@@ -984,7 +984,7 @@ export default class AutoNumericHelper {
      *
      * @param {number} value
      * @param {int} decimalPlacesLimit
-     * @returns {*}
+     * @returns {number}
      */
     static addAndRoundToNearestAuto(value, decimalPlacesLimit) {
         return this.modifyAndRoundToNearestAuto(value, true, decimalPlacesLimit);
@@ -996,7 +996,7 @@ export default class AutoNumericHelper {
      *
      * @param {number} value
      * @param {int} decimalPlacesLimit
-     * @returns {*}
+     * @returns {number}
      */
     static subtractAndRoundToNearestAuto(value, decimalPlacesLimit) {
         return this.modifyAndRoundToNearestAuto(value, false, decimalPlacesLimit);
@@ -1009,9 +1009,9 @@ export default class AutoNumericHelper {
      * Based on http://stackoverflow.com/a/17025392/2834898
      *
      * @param {string} arabicNumbers
-     * @param {boolean} returnANumber If `true`, return a Number, otherwise return a String
-     * @param {boolean} parseDecimalCharacter
-     * @param {boolean} parseThousandSeparator
+     * @param {boolean} [returnANumber=true] If `true`, return a Number, otherwise return a String
+     * @param {boolean} [parseDecimalCharacter=false]
+     * @param {boolean} [parseThousandSeparator=false]
      * @returns {string|number|NaN}
      */
     static arabicToLatinNumbers(arabicNumbers, returnANumber = true, parseDecimalCharacter = false, parseThousandSeparator = false) {
@@ -1064,9 +1064,9 @@ export default class AutoNumericHelper {
      *
      * @param {string} eventName
      * @param {HTMLElement|HTMLDocument|EventTarget} element
-     * @param {object} detail
-     * @param {boolean} bubbles Set to `true` if the event must bubble up
-     * @param {boolean} cancelable Set to `true` if the event must be cancelable
+     * @param {object} [detail=null]
+     * @param {boolean} [bubbles=true] Set to `true` if the event must bubble up
+     * @param {boolean} [cancelable=true] Set to `true` if the event must be cancelable
      */
     static triggerEvent(eventName, element = document, detail = null, bubbles = true, cancelable = true) {
         let event;
@@ -1081,13 +1081,21 @@ export default class AutoNumericHelper {
     }
 
     /**
+     * This typedef is based on big.js object properties: https://mikemcl.github.io/big.js/#instance-properties
+     * @typedef {Object} Big
+     * @property {number[]} c  coefficient: Array of single digits   	
+     * @property {number} e    exponent: an integer in the range of -1e+6 to 1e+6 inclusive
+     * @property {-1|1} s      sign: -1 or 1
+     */
+
+    /**
      * Function to parse minimumValue, maximumValue & the input value to prepare for testing to determine if the value falls within the min / max range.
      * Return an object example: minimumValue: "999999999999999.99" returns the following "{s: -1, e: 12, c: Array[15]}".
      *
      * This function is adapted from Big.js https://github.com/MikeMcl/big.js/. Many thanks to Mike.
      *
      * @param {number|string} value A numeric value.
-     * @returns {{}}
+     * @returns {Big}
      */
     static parseStr(value) {
         if (AutoNumericHelper.isUndefinedOrNullOrEmpty(value)) {
@@ -1160,9 +1168,9 @@ export default class AutoNumericHelper {
      *
      * This function is adapted from Big.js https://github.com/MikeMcl/big.js/. Many thanks to Mike.
      *
-     * @param {object} y Big number instance
-     * @param {object} x Big number instance
-     * @returns {*}
+     * @param {Big} y Big number instance
+     * @param {Big} x Big number instance
+     * @returns {-1|0|1} Comparison result: 0 if x=y, -1 if y>x, +1 if y<x
      */
     static testMinMax(y, x) {
         const xc = x.c;
@@ -1220,13 +1228,13 @@ export default class AutoNumericHelper {
      * Generate a random string.
      * cf. http://stackoverflow.com/a/8084248/2834898
      *
-     * @param {Number} strLength Length of the generated string (in character count)
+     * @param {Number} [strLength=5] Length of the generated string (in character count, optional, default: 5)
      * @returns {string}
      */
     static randomString(strLength = 5) {
         return Math.random()
             .toString(36)
-            .substr(2, strLength);
+            .substring(2, 2 + strLength);
     }
 
     /**
@@ -1250,7 +1258,7 @@ export default class AutoNumericHelper {
      * Retrieve the current element value.
      *
      * @param {HTMLElement|HTMLInputElement|EventTarget} element
-     * @returns {number|string|null}
+     * @returns {string|null}
      */
     static getElementValue(element) {
         if (element.tagName.toLowerCase() === 'input') {
@@ -1264,7 +1272,7 @@ export default class AutoNumericHelper {
      * Modify the element value directly.
      *
      * @param {HTMLElement|HTMLInputElement} element
-     * @param {number|string|null} value
+     * @param {number|string|null} [value=null]
      */
     static setElementValue(element, value = null) {
         if (element.tagName.toLowerCase() === 'input') {
@@ -1280,7 +1288,7 @@ export default class AutoNumericHelper {
      * Note: This does not work with contenteditable elements
      *
      * @param {HTMLElement|HTMLInputElement} element
-     * @param {string|null} message
+     * @param {string|null} [message='Invalid'] Custom message (optional, default: 'Invalid')
      * @throws Error
      */
     static setInvalidState(element, message = 'Invalid') {
@@ -1322,9 +1330,9 @@ export default class AutoNumericHelper {
      * @example camelize('data-currency-symbol') => 'currencySymbol'
      *
      * @param {string} str Text to camelize
-     * @param {string} separator Character that separate each word
-     * @param {boolean} removeData If set to `true`, remove the `data-` part that you can find on some html attributes
-     * @param {boolean} skipFirstWord If set to `true`, do not capitalize the very first word
+     * @param {string} [separator='-'] Character that separate each word (Optional, default: '-')
+     * @param {boolean} [removeData=true] If set to `true`, remove the `data-` part that you can find on some html attributes (Optional, default: true)
+     * @param {boolean} [skipFirstWord=true] If set to `true`, do not capitalize the very first word (Optional, default: true)
      * @returns {string|null}
      */
     static camelize(str, separator = '-', removeData = true, skipFirstWord = true) {
@@ -1409,7 +1417,7 @@ export default class AutoNumericHelper {
      * Remove the trailing zeros in the decimal part of a number.
      *
      * @param {string} numericString
-     * @returns {*}
+     * @returns {string}
      */
     static trimPaddedZerosFromDecimalPlaces(numericString) {
         numericString = String(numericString);
@@ -1437,7 +1445,7 @@ export default class AutoNumericHelper {
     /**
      * Return the top-most hovered item by the mouse cursor.
      *
-     * @returns {*}
+     * @returns {Element}
      */
     static getHoveredElement() {
         const hoveredElements = [...document.querySelectorAll(':hover')];
@@ -1445,12 +1453,12 @@ export default class AutoNumericHelper {
     }
 
     /**
-     * Return the given array trimmed to the given length.
+     * Return the given array trimmed to the given length. The original array is also trimmed.
      * @example arrayTrim([1, 2, 3, 4], 2) -> [1, 2]
      *
      * @param {Array} array
      * @param {Number} length
-     * @returns {*}
+     * @returns {Array}
      */
     static arrayTrim(array, length) {
         const arrLength = array.length;
@@ -1507,11 +1515,11 @@ export default class AutoNumericHelper {
     }
 
     /**
-     * Returns the object `obj` property 'propertyName', or `null` if the property is not found
+     * Returns `obj` objects's property descriptor of the property 'propertyName', or `null` if the property is not found
      *
      * @param {object} obj
      * @param {string|number} propertyName
-     * @returns {*|null}
+     * @returns {PropertyDescriptor|null}
      */
     static getGetterSetter(obj, propertyName) {
         while ((obj = Object.getPrototypeOf(obj))) { // double () to make eslint happy

--- a/test/unit/autoNumeric.spec.js
+++ b/test/unit/autoNumeric.spec.js
@@ -9096,3 +9096,86 @@ describe(`The Math expression lexer and parser`, () => {
         expect(() => testParser('(4+1) * 2 - (104587.23 * 8 - (-7))')).toThrow();
     });
 });
+
+describe(`AutoNumericHelper functions()`, () => {
+    it(`'replaceCharAt()' should return the correct string`, () => {
+        expect(AutoNumericHelper.replaceCharAt('abcdef', 4, '1')).toEqual('abcd1f');  // Normal replace
+        expect(AutoNumericHelper.replaceCharAt('abcdef', 1, '123')).toEqual('a123ef');  // Replace more characters
+
+        expect(AutoNumericHelper.replaceCharAt('abcdef', 0, '12345678')).toEqual('12345678');  // newCharacter is longer than the original
+        expect(AutoNumericHelper.replaceCharAt('abcdef', 6, '12')).toEqual('abcdef12');  // Replace starts at the end
+        expect(AutoNumericHelper.replaceCharAt('abcdef', 99, '12')).toEqual('abcdef12');  // Replace starts after the end
+    });
+
+    it(`'clampToRangeLimits()' should return the correct number`, () => {
+        const settings = { minimumValue: '-100', maximumValue: '50.5123' };
+        expect(AutoNumericHelper.clampToRangeLimits(10.2, settings)).toEqual(10.2); 
+        expect(AutoNumericHelper.clampToRangeLimits('10.2', settings)).toEqual(10.2); 
+
+        expect(AutoNumericHelper.clampToRangeLimits(-200, settings)).toEqual(-100);
+        expect(AutoNumericHelper.clampToRangeLimits('-200', settings)).toEqual(-100);
+
+        expect(AutoNumericHelper.clampToRangeLimits(200, settings)).toEqual(50.5123);
+        expect(AutoNumericHelper.clampToRangeLimits('200', settings)).toEqual(50.5123);
+    });
+
+    it(`'forceDecimalPlaces()' should return the correct number or string`, () => {
+        expect(AutoNumericHelper.forceDecimalPlaces(123.45678, 0)).toEqual('123.');
+        expect(AutoNumericHelper.forceDecimalPlaces(123.45678, 1)).toEqual('123.4');
+        expect(AutoNumericHelper.forceDecimalPlaces(123.45678, 2)).toEqual('123.45');
+        expect(AutoNumericHelper.forceDecimalPlaces(123.45678, 3)).toEqual('123.456');
+
+        expect(AutoNumericHelper.forceDecimalPlaces(123, 3)).toEqual(123);
+    });
+
+    it(`'roundToNearest()' should return the correct number or string`, () => {
+        expect(AutoNumericHelper.roundToNearest(264789, 10000)).toEqual(260000);
+        expect(AutoNumericHelper.roundToNearest(264789, 10)).toEqual(264790);
+        expect(AutoNumericHelper.roundToNearest(0, 10)).toEqual(0);
+
+        expect(() => { AutoNumericHelper.roundToNearest(264789, 0); }).toThrow();
+    });
+
+    it(`'roundToNearest()' should return the correct number`, () => {
+        expect(AutoNumericHelper.roundToNearest(264789, 10000)).toEqual(260000);
+        expect(AutoNumericHelper.roundToNearest(264789, 10)).toEqual(264790);
+        expect(AutoNumericHelper.roundToNearest(0, 10)).toEqual(0);
+
+        expect(() => { AutoNumericHelper.roundToNearest(264789, 0); }).toThrow();
+    });
+
+    it(`'indexFirstNonZeroDecimalPlace()' should return the correct number`, () => {
+        expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(0.0)).toEqual(0);
+        expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(1.00)).toEqual(0);
+        expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(0.12)).toEqual(0);  // TODO is that special if (.. === -1) in indexFirstNonZeroDecimalPlace intentional?
+        expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(0.1234)).toEqual(0);
+        expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(0.01234)).toEqual(2);
+        expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(0.001234)).toEqual(3);
+        expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(0.0001234)).toEqual(4);
+
+        expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace('123.0001234')).toEqual(4);
+    });
+
+    it(`'addAndRoundToNearestAuto()' should return the correct number`, () => {
+        const eps = 0.00000001;
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(1, 0)).toEqual(2);  // Offset: 1
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(14, 0)).toEqual(20);  // Offset: 10
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(17, 0)).toEqual(30);  // Offset: 10
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(143, 0)).toEqual(150);  // Offset: 10
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(1278, 0)).toEqual(1400);  // Offset: 100
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(28456, 0)).toEqual(28600);  // Offset: 100
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(276345, 0)).toEqual(277000); // Offset: 1000
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(4534061, 0)).toEqual(4540000); // Offset: 10000
+
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(0, 4)).toBeCloseTo(0.0001, eps); // Offset: 1e-4
+
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(1.12, 2)).toEqual(2); // Offset: 1
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(1.123, 3)).toEqual(2); // Offset: 1
+
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(0.412, 4)).toEqual(0.500); // Offset: 0.1  // source of difference (compared to the comment in modifyAndRoundToNearestAuto) see special rule in indexFirstNonZeroDecimalPlace
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(0.0412, 4)).toEqual(0.0420); // Offset: 0.001
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(0.0041, 4)).toBeCloseTo(0.0042, eps); // Offset: 0.0001
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(0.0004, 4)).toEqual(0.0005); // Offset: 0.0001
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(0.0000, 4)).toBeCloseTo(0.0001, eps); // Offset: 0.0001
+    });
+});

--- a/test/unit/autoNumeric.spec.js
+++ b/test/unit/autoNumeric.spec.js
@@ -9147,11 +9147,18 @@ describe(`AutoNumericHelper functions()`, () => {
     it(`'indexFirstNonZeroDecimalPlace()' should return the correct number`, () => {
         expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(0.0)).toEqual(0);
         expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(1.00)).toEqual(0);
-        expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(0.12)).toEqual(0);  // TODO is that special if (.. === -1) in indexFirstNonZeroDecimalPlace intentional?
-        expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(0.1234)).toEqual(0);
+        expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(0.12)).toEqual(1);
+        expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(0.1204)).toEqual(1);
+        expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(0.1234)).toEqual(1);
         expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(0.01234)).toEqual(2);
+        expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(0.01204)).toEqual(2);
+        expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(0.012040)).toEqual(2);
         expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(0.001234)).toEqual(3);
+        expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(0.001004)).toEqual(3);
+        expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(0.00100400)).toEqual(3);
         expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(0.0001234)).toEqual(4);
+        expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(0.0001204)).toEqual(4);
+        expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace(0.0001204000)).toEqual(4);
 
         expect(AutoNumericHelper.indexFirstNonZeroDecimalPlace('123.0001234')).toEqual(4);
     });
@@ -9172,7 +9179,20 @@ describe(`AutoNumericHelper functions()`, () => {
         expect(AutoNumericHelper.addAndRoundToNearestAuto(1.12, 2)).toEqual(2); // Offset: 1
         expect(AutoNumericHelper.addAndRoundToNearestAuto(1.123, 3)).toEqual(2); // Offset: 1
 
-        expect(AutoNumericHelper.addAndRoundToNearestAuto(0.412, 4)).toEqual(0.500); // Offset: 0.1  // source of difference (compared to the comment in modifyAndRoundToNearestAuto) see special rule in indexFirstNonZeroDecimalPlace
+        // Special case when the `value` to round is between -1 and 1, excluded
+        // 2 decimal places
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(0.12, 2)).toEqual(0.13); // Offset: 0.01
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(0.01, 2)).toEqual(0.02); // Offset: 0.01
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(0.00, 2)).toEqual(0.01); // Offset: 0.01
+
+        // 3 decimal places
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(0.123, 3)).toEqual(0.130);          // Offset: 0.01
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(0.012, 3)).toBeCloseTo(0.013, eps); // Offset: 0.001
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(0.001, 3)).toEqual(0.002);          // Offset: 0.001
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(0.000, 3)).toEqual(0.001);          // Offset: 0.001
+
+        // 4 decimal places
+        expect(AutoNumericHelper.addAndRoundToNearestAuto(0.412, 4)).toEqual(0.420);            // Offset: 0.01
         expect(AutoNumericHelper.addAndRoundToNearestAuto(0.0412, 4)).toEqual(0.0420); // Offset: 0.001
         expect(AutoNumericHelper.addAndRoundToNearestAuto(0.0041, 4)).toBeCloseTo(0.0042, eps); // Offset: 0.0001
         expect(AutoNumericHelper.addAndRoundToNearestAuto(0.0004, 4)).toEqual(0.0005); // Offset: 0.0001


### PR DESCRIPTION
- Reviewed and improved some jsdoc comments. Marked parameters as optional where it has a default value. I've also included the default value in the jsdoc comment, hopefully some IDEs can use this piece of info. Please also see #497.
- replaced the deprecated substr() with the supported substring() calls, 
- other minor fixes. 
- added a few unit tests for AutoNumericHelper.js