### PR TITLE
Attach built dist files to GitHub releases (#805)

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -38,7 +38,7 @@ jobs:
         run: yarn build
 
       - name: Upload dist files to the release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             dist/autoNumeric.js

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -1,0 +1,47 @@
+name: Attach dist files to release
+
+# When a release is published, build the library and upload the generated
+# `dist` files as release assets. This lets people download the exact
+# `autoNumeric.js` / `autoNumeric.min.js` the maintainers built, straight
+# from the GitHub release page, without going through a CDN or npm.
+# See issue #805.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write # Needed to upload assets to the release
+
+jobs:
+  build-and-attach:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the tagged commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '16'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: 'true'
+
+      - name: Build the dist files
+        run: yarn build
+
+      - name: Upload dist files to the release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/autoNumeric.js
+            dist/autoNumeric.js.map
+            dist/autoNumeric.min.js
+            dist/autoNumeric.min.js.map


### PR DESCRIPTION
## What this does

This adds a GitHub Actions workflow (`.github/workflows/release-assets.yml`) that builds the library and uploads the generated `dist` files as assets whenever a release is published.

Closes #805.

## Why

In #805 the request was to be able to download the minified build straight from the GitHub release page, so people get exactly the file the maintainers built without having to trust a CDN or pull it from npm. In the thread @AlexandreBonneau was fine with it as long as the process is automatic, and @laundmo pointed at `softprops/action-gh-release` for doing it in CI. This PR implements that.

## How it works

The workflow runs on `release: published`, so it fits the existing flow of picking a tag and creating a release from the GitHub UI. On each published release it:

1. checks out the tagged commit,
2. installs deps and runs `yarn build` (same Node 16 setup as the current Travis build, so the output matches what gets published to npm),
3. uploads the four consumable files as release assets:
   - `autoNumeric.js`
   - `autoNumeric.js.map`
   - `autoNumeric.min.js`
   - `autoNumeric.min.js.map`

It only runs on release publish, so it does not touch or interfere with the existing Travis npm deploy. I left the webpack `.gz` files out since GitHub serves downloads compressed on its own, but I'm happy to add them if you'd prefer.

## Proof that it works

Since this only triggers on a real release, I tested the whole thing end to end on my fork by publishing a throwaway release. The run built the dist files and attached all four assets successfully:

- Workflow run: https://github.com/Vansh-Sharma27/autoNumeric/actions/runs/26727730395
- Resulting release with the attached assets: https://github.com/Vansh-Sharma27/autoNumeric/releases/tag/ci-proof-805

The asset sizes match a local `yarn build` exactly (`autoNumeric.js` 699044 bytes, `autoNumeric.min.js` 209791 bytes).

Note: GitHub shows a generic "Node.js 20 actions are deprecated" notice on the run. That is just a forward-looking warning that applies to the current major versions of `actions/checkout`, `actions/setup-node` and `action-gh-release`; it is not an error and the run passes.