### PR TITLE
fix: quote form attribute selector to support ids with special charac…

### DIFF
--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -3157,7 +3157,7 @@ export default class AutoNumeric {
             return [];
         }
         const elementsInside = [...formElement.querySelectorAll('[contenteditable=true]')];
-        const elementsOutside = [...document.querySelectorAll(`*:not(input)[form=${formElement.getAttribute('id')}][contenteditable=true]`)];
+        const elementsOutside = [...document.querySelectorAll(`*:not(input)[form="${formElement.getAttribute('id')}"][contenteditable=true]`)];
 
         return AutoNumericHelper.arrayUnique(elementsInside, elementsOutside);
     }


### PR DESCRIPTION
…ters (fixes #829)

Wrap the form attribute value in double quotes when building the selector. This prevents invalid selectors when form IDs contain special characters such as dots (e.g. "my.form.id"), ensuring elements are correctly matched.