### PR TITLE
Ceiling rounding should look past the first dropped digit

### DIFF
--- a/src/AutoNumeric.js
+++ b/src/AutoNumeric.js
@@ -5873,6 +5873,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
         }
 
         const lastDigit = Number(inputValue.charAt(roundedStrLength + 1));
+        const hasStickyRemainder = /[1-9]/.test(inputValue.substring(roundedStrLength + 1));
         let inputValueArray = inputValue.substring(0, roundedStrLength + 1).split('');
         let odd;
         if (inputValue.charAt(roundedStrLength) === '.') {
@@ -5881,7 +5882,7 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
             odd = inputValue.charAt(roundedStrLength) % 2;
         }
 
-        if (this._shouldRoundUp(lastDigit, settings, negativeSign, odd)) {
+        if (this._shouldRoundUp(lastDigit, settings, negativeSign, odd, hasStickyRemainder)) {
             // Round up the last digit if required, and continue until no more 9's are found
             for (let i = (inputValueArray.length - 1); i >= 0; i -= 1) {
                 if (inputValueArray[i] !== '.') {
@@ -5984,10 +5985,11 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
      * @param {object} settings
      * @param {string} negativeSign This variable comes from `_prepareValueForRounding()`, which return `'-'` if the initial value was negative
      * @param {number} odd
+     * @param {boolean} hasStickyRemainder `true` if any digit after the cutoff is nonzero
      * @returns {boolean}
      * @private
      */
-    static _shouldRoundUp(lastDigit, settings, negativeSign, odd) {
+    static _shouldRoundUp(lastDigit, settings, negativeSign, odd, hasStickyRemainder) {
         return (lastDigit > 4 && settings.roundingMethod === AutoNumeric.options.roundingMethod.halfUpSymmetric)                                     || // Round half up symmetric
             (lastDigit > 4 && settings.roundingMethod === AutoNumeric.options.roundingMethod.halfUpAsymmetric && negativeSign === '')                || // Round half up asymmetric positive values
             (lastDigit > 5 && settings.roundingMethod === AutoNumeric.options.roundingMethod.halfUpAsymmetric && negativeSign === '-')               || // Round half up asymmetric negative values
@@ -5996,9 +5998,9 @@ To solve that, you'd need to either set \`decimalPlacesRawValue\` to \`null\`, o
             (lastDigit > 4 && settings.roundingMethod === AutoNumeric.options.roundingMethod.halfDownAsymmetric && negativeSign === '-')             || // Round half down asymmetric negative values
             (lastDigit > 5 && settings.roundingMethod === AutoNumeric.options.roundingMethod.halfEvenBankersRounding)                                ||
             (lastDigit === 5 && settings.roundingMethod === AutoNumeric.options.roundingMethod.halfEvenBankersRounding && odd === 1)                 ||
-            (lastDigit > 0 && settings.roundingMethod === AutoNumeric.options.roundingMethod.toCeilingTowardPositiveInfinity && negativeSign === '') ||
-            (lastDigit > 0 && settings.roundingMethod === AutoNumeric.options.roundingMethod.toFloorTowardNegativeInfinity && negativeSign === '-')  ||
-            (lastDigit > 0 && settings.roundingMethod === AutoNumeric.options.roundingMethod.upRoundAwayFromZero);                                      // Round up away from zero
+            (hasStickyRemainder && settings.roundingMethod === AutoNumeric.options.roundingMethod.toCeilingTowardPositiveInfinity && negativeSign === '') ||
+            (hasStickyRemainder && settings.roundingMethod === AutoNumeric.options.roundingMethod.toFloorTowardNegativeInfinity && negativeSign === '-')  ||
+            (hasStickyRemainder && settings.roundingMethod === AutoNumeric.options.roundingMethod.upRoundAwayFromZero);                                      // Round up away from zero
     }
 
     /**

--- a/test/unit/autoNumeric.spec.js
+++ b/test/unit/autoNumeric.spec.js
@@ -1922,6 +1922,17 @@ describe('autoNumeric options and `options.*` methods', () => {
             expect(aNInput.getFormatted()).toEqual('-1,120.00');
         });
 
+        it('should round away from zero when the first dropped digit is 0 but a later digit is nonzero', () => {
+            aNInput.update({
+                decimalPlaces : 1,
+                roundingMethod: AutoNumeric.options.roundingMethod.upRoundAwayFromZero,
+            });
+            aNInput.set(1.5001);
+            expect(aNInput.getFormatted()).toEqual('1.6');
+            aNInput.set(-1.5001);
+            expect(aNInput.getFormatted()).toEqual('-1.6');
+        });
+
         it('should round correctly with the method downRoundTowardZero', () => {
             aNInput.update({ roundingMethod: AutoNumeric.options.roundingMethod.downRoundTowardZero });
             // Positive values
@@ -1956,6 +1967,19 @@ describe('autoNumeric options and `options.*` methods', () => {
             expect(aNInput.getFormatted()).toEqual('-1,119.44');
             aNInput.set(-1119.995);
             expect(aNInput.getFormatted()).toEqual('-1,119.99');
+        });
+
+        it('should ceiling-round when the first dropped digit is 0 but a later digit is nonzero', () => {
+            aNInput.update({
+                decimalPlaces : 1,
+                roundingMethod: AutoNumeric.options.roundingMethod.toCeilingTowardPositiveInfinity,
+            });
+            aNInput.set(1.5001);
+            expect(aNInput.getFormatted()).toEqual('1.6');
+            aNInput.set(1.5000);
+            expect(aNInput.getFormatted()).toEqual('1.5');
+            aNInput.set(-1.5001);
+            expect(aNInput.getFormatted()).toEqual('-1.5');
         });
 
         it('should round correctly with the method toCeilingTowardPositiveInfinity and a custom negative sign', () => {
@@ -1995,6 +2019,17 @@ describe('autoNumeric options and `options.*` methods', () => {
             expect(aNInput.getFormatted()).toEqual('-1,119.45');
             aNInput.set(-1119.995);
             expect(aNInput.getFormatted()).toEqual('-1,120.00');
+        });
+
+        it('should floor-round when the first dropped digit is 0 but a later digit is nonzero', () => {
+            aNInput.update({
+                decimalPlaces : 1,
+                roundingMethod: AutoNumeric.options.roundingMethod.toFloorTowardNegativeInfinity,
+            });
+            aNInput.set(1.5001);
+            expect(aNInput.getFormatted()).toEqual('1.5');
+            aNInput.set(-1.5001);
+            expect(aNInput.getFormatted()).toEqual('-1.6');
         });
 
         it('should round correctly with the method toFloorTowardNegativeInfinity', () => {
@@ -7502,6 +7537,16 @@ describe('Static autoNumeric functions', () => {
             expect(AutoNumeric.format(0.004796656, AutoNumeric.getPredefinedOptions().percentageEU3dec)).toEqual('0,480\u202f%');
             expect(AutoNumeric.format(0.004742656, AutoNumeric.getPredefinedOptions().percentageEU3dec)).toEqual('0,474\u202f%');
             expect(AutoNumeric.format(-0.002541148, AutoNumeric.getPredefinedOptions().percentageEU3dec)).toEqual('-0,254\u202f%');
+        });
+
+        it('should ceiling-round when the first dropped digit is 0 but a later digit is nonzero', () => {
+            expect(AutoNumeric.format(1.5001, { decimalPlaces: 1, roundingMethod: 'C' })).toEqual('1.6');
+            expect(AutoNumeric.format(1.5000, { decimalPlaces: 1, roundingMethod: 'C' })).toEqual('1.5');
+            expect(AutoNumeric.format(-1.5001, { decimalPlaces: 1, roundingMethod: 'C' })).toEqual('-1.5');
+            expect(AutoNumeric.format(1.5001, { decimalPlaces: 1, roundingMethod: 'F' })).toEqual('1.5');
+            expect(AutoNumeric.format(-1.5001, { decimalPlaces: 1, roundingMethod: 'F' })).toEqual('-1.6');
+            expect(AutoNumeric.format(1.5001, { decimalPlaces: 1, roundingMethod: 'U' })).toEqual('1.6');
+            expect(AutoNumeric.format(-1.5001, { decimalPlaces: 1, roundingMethod: 'U' })).toEqual('-1.6');
         });
 
         it('should correctly format `valuesToStrings` values', () => {


### PR DESCRIPTION
`roundingMethod: 'C'` (ceiling toward +∞) only inspected the first dropped digit. When that digit was `0` but a later digit was nonzero, the value was truncated instead of rounded up.

```js
AutoNumeric.format(1.5001, { decimalPlaces: 1, roundingMethod: 'C' })
// was '1.5', now '1.6'
```

C, F, and U now treat any nonzero remainder after the cutoff as sticky. The half-even / half-up table is unchanged.

Reported by @eliseevmikhail.

Fixes #833